### PR TITLE
feat: add common.sh with TDD tests (Phase 1)

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# common.sh — Shared functions for cross-repo issue sync.
+
+# Parse "Source: owner/repo#N" from issue body. Returns the ref or empty.
+parse_source_ref() {
+  local body="$1"
+  echo -e "$body" | grep -oP '(?<=Source:\s{0,10})\S+' | head -1
+}
+
+# Extract a component from a source ref (owner/repo#N).
+# Usage: split_source_ref "owner/repo#42" owner|repo|number
+split_source_ref() {
+  local ref="$1" part="$2"
+  [[ "$ref" =~ ^([^/]+)/([^#]+)#([0-9]+)$ ]] || return 0
+  case "$part" in
+    owner)  echo "${BASH_REMATCH[1]}" ;;
+    repo)   echo "${BASH_REMATCH[2]}" ;;
+    number) echo "${BASH_REMATCH[3]}" ;;
+  esac
+}
+
+# Check if an event should be skipped to prevent sync loops.
+# Returns 0 (true) if loop detected, 1 (false) if safe.
+is_loop() {
+  local actor="$1" comment="$2"
+  [[ "$actor" == "github-actions[bot]" ]] && return 0
+  [[ "$comment" == "[sync-bot]"* ]] && return 0
+  [[ "$comment" == "[source]"* ]] && return 0
+  [[ "$comment" == "[tracker]"* ]] && return 0
+  return 1
+}
+
+# Check if an issue is tracker-only (no Source ref in body).
+# Returns 0 (true) if tracker-only, 1 (false) if mirror.
+is_tracker_only() {
+  local body="$1"
+  local ref
+  ref="$(parse_source_ref "$body")"
+  [[ -z "$ref" ]]
+}
+
+# Build mirror issue title from repo name and source title.
+build_mirror_title() {
+  local repo="$1" title="$2"
+  echo "[$repo] $title"
+}
+
+# Build mirror issue body with source reference.
+build_mirror_body() {
+  local source_ref="$1"
+  echo "Source: $source_ref"
+}

--- a/tests/unit/test_common.bats
+++ b/tests/unit/test_common.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+# Phase 1 TDD: tests for scripts/common.sh
+# RED phase — these tests should FAIL until common.sh is implemented.
+
+setup() {
+  export TMPDIR="${BATS_TMPDIR:-/tmp/claude-1000/bats-tmp}"
+  source "$BATS_TEST_DIRNAME/../../scripts/common.sh"
+}
+
+# --- parse_source_ref ---
+
+@test "parse_source_ref extracts owner/repo#N from issue body" {
+  body="Some text\nSource: qte77/my-repo#42\nMore text"
+  result="$(parse_source_ref "$body")"
+  [ "$result" = "qte77/my-repo#42" ]
+}
+
+@test "parse_source_ref returns empty for body without Source line" {
+  body="This is a tracker-only issue\nNo source reference here"
+  result="$(parse_source_ref "$body")"
+  [ -z "$result" ]
+}
+
+@test "parse_source_ref returns empty for empty body" {
+  result="$(parse_source_ref "")"
+  [ -z "$result" ]
+}
+
+@test "parse_source_ref handles Source line with extra whitespace" {
+  body="Source:   qte77/some-repo#7  "
+  result="$(parse_source_ref "$body")"
+  [ "$result" = "qte77/some-repo#7" ]
+}
+
+# --- split_source_ref ---
+
+@test "split_source_ref extracts owner from ref" {
+  result="$(split_source_ref "qte77/my-repo#42" owner)"
+  [ "$result" = "qte77" ]
+}
+
+@test "split_source_ref extracts repo from ref" {
+  result="$(split_source_ref "qte77/my-repo#42" repo)"
+  [ "$result" = "my-repo" ]
+}
+
+@test "split_source_ref extracts number from ref" {
+  result="$(split_source_ref "qte77/my-repo#42" number)"
+  [ "$result" = "42" ]
+}
+
+@test "split_source_ref returns empty for invalid ref" {
+  result="$(split_source_ref "not-a-ref" owner)"
+  [ -z "$result" ]
+}
+
+# --- is_loop ---
+
+@test "is_loop returns 0 for github-actions[bot] actor" {
+  is_loop "github-actions[bot]" ""
+}
+
+@test "is_loop returns 0 for sync-bot prefixed comment" {
+  is_loop "some-human" "[sync-bot] Updated from source"
+}
+
+@test "is_loop returns 0 for source prefixed comment" {
+  is_loop "some-human" "[source] Original comment text"
+}
+
+@test "is_loop returns 0 for tracker prefixed comment" {
+  is_loop "some-human" "[tracker] Comment from tracker"
+}
+
+@test "is_loop returns 1 for human actor with normal comment" {
+  ! is_loop "some-human" "This is a regular comment"
+}
+
+@test "is_loop returns 1 for human actor with empty comment" {
+  ! is_loop "some-human" ""
+}
+
+# --- is_tracker_only ---
+
+@test "is_tracker_only returns 0 when no Source ref in body" {
+  is_tracker_only "Just a tracker issue, no source"
+}
+
+@test "is_tracker_only returns 1 when Source ref present" {
+  ! is_tracker_only "Source: qte77/repo#1"
+}
+
+# --- build_mirror_title ---
+
+@test "build_mirror_title formats [repo] title" {
+  result="$(build_mirror_title "my-repo" "Fix the bug")"
+  [ "$result" = "[my-repo] Fix the bug" ]
+}
+
+@test "build_mirror_title handles empty title" {
+  result="$(build_mirror_title "repo" "")"
+  [ "$result" = "[repo] " ]
+}
+
+# --- build_mirror_body ---
+
+@test "build_mirror_body includes Source ref" {
+  result="$(build_mirror_body "qte77/repo#5")"
+  echo "$result" | grep -q "Source: qte77/repo#5"
+}


### PR DESCRIPTION
## Summary

- Pure functions for cross-repo issue sync in `scripts/common.sh`
- 19 BATS unit tests in `tests/unit/test_common.bats`
- TDD Red-Green-Refactor cycle completed

## Functions

- `parse_source_ref` — extract `Source: owner/repo#N` from issue body
- `split_source_ref` — decompose ref into owner, repo, number
- `is_loop` — detect sync loops (bot actor, prefixed comments)
- `is_tracker_only` — check if issue has no source ref
- `build_mirror_title/body` — format mirror issue content

## Test plan

- [x] 19/19 BATS tests passing locally

Generated with Claude <noreply@anthropic.com>