### PR TITLE
feat: add sync-back.sh with TDD tests (Phase 2)

### DIFF
--- a/scripts/sync-back.sh
+++ b/scripts/sync-back.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# sync-back.sh — Reverse sync: tracker issue events → source repo.
+# Requires common.sh to be sourced first.
+
+DRY_RUN="${DRY_RUN:-false}"
+
+# Extract issue number from source ref.
+_issue_num() {
+  split_source_ref "$1" number
+}
+
+# Extract owner/repo from source ref.
+_issue_repo() {
+  local owner repo
+  owner="$(split_source_ref "$1" owner)"
+  repo="$(split_source_ref "$1" repo)"
+  [[ -n "$owner" && -n "$repo" ]] && echo "$owner/$repo"
+}
+
+handle_issue_closed() {
+  local ref="$1" repo="$2"
+  [[ -z "$ref" ]] && return 0
+  local num
+  num="$(_issue_num "$ref")"
+  gh issue close "$num" -R "$repo"
+}
+
+handle_issue_reopened() {
+  local ref="$1" repo="$2"
+  [[ -z "$ref" ]] && return 0
+  local num
+  num="$(_issue_num "$ref")"
+  gh issue reopen "$num" -R "$repo"
+}
+
+handle_issue_labeled() {
+  local ref="$1" repo="$2" label="$3"
+  local num
+  num="$(_issue_num "$ref")"
+  gh issue edit "$num" -R "$repo" --add-label "$label"
+}
+
+handle_issue_unlabeled() {
+  local ref="$1" repo="$2" label="$3"
+  local num
+  num="$(_issue_num "$ref")"
+  gh issue edit "$num" -R "$repo" --remove-label "$label"
+}
+
+handle_issue_edited() {
+  local ref="$1" repo="$2" title="$3"
+  local num
+  num="$(_issue_num "$ref")"
+  gh issue edit "$num" -R "$repo" --title "$title"
+}
+
+handle_issue_assigned() {
+  local ref="$1" repo="$2" assignee="$3"
+  local num
+  num="$(_issue_num "$ref")"
+  gh issue edit "$num" -R "$repo" --add-assignee "$assignee"
+}
+
+handle_issue_unassigned() {
+  local ref="$1" repo="$2" assignee="$3"
+  local num
+  num="$(_issue_num "$ref")"
+  gh issue edit "$num" -R "$repo" --remove-assignee "$assignee"
+}
+
+handle_issue_comment() {
+  local ref="$1" repo="$2" comment="$3"
+  local num
+  num="$(_issue_num "$ref")"
+  gh issue comment "$num" -R "$repo" --body "[tracker] $comment"
+}
+
+# Dispatch an event to the appropriate handler.
+# Args: action ref repo label title assignee [comment]
+dispatch_event() {
+  local action="$1" ref="$2" repo="$3" label="$4" title="$5" assignee="$6" comment="${7:-}"
+
+  # Guard: skip tracker-only issues
+  [[ -z "$ref" ]] && return 0
+
+  # Guard: dry run
+  [[ "$DRY_RUN" == "true" ]] && { echo "[dry-run] Would dispatch: $action for $ref"; return 0; }
+
+  case "$action" in
+    closed)           handle_issue_closed "$ref" "$repo" ;;
+    reopened)         handle_issue_reopened "$ref" "$repo" ;;
+    labeled)          handle_issue_labeled "$ref" "$repo" "$label" ;;
+    unlabeled)        handle_issue_unlabeled "$ref" "$repo" "$label" ;;
+    edited)           handle_issue_edited "$ref" "$repo" "$title" ;;
+    assigned)         handle_issue_assigned "$ref" "$repo" "$assignee" ;;
+    unassigned)       handle_issue_unassigned "$ref" "$repo" "$assignee" ;;
+    comment_created)  handle_issue_comment "$ref" "$repo" "$comment" ;;
+    *) echo "Unknown action: $action" >&2 ;;
+  esac
+}

--- a/tests/test_helper/gh_mock.bash
+++ b/tests/test_helper/gh_mock.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# gh_mock.bash — Mock gh CLI for BATS tests.
+# Records calls to GH_MOCK_LOG for assertion. Returns canned responses.
+
+export GH_MOCK_LOG="${GH_MOCK_LOG:-$BATS_TMPDIR/gh_mock.log}"
+
+gh() {
+  echo "gh $*" >> "$GH_MOCK_LOG"
+
+  case "$1 $2" in
+    "issue close")   echo "" ;;
+    "issue reopen")  echo "" ;;
+    "issue edit")    echo "" ;;
+    "issue comment") echo "" ;;
+    "issue view")
+      # Return canned issue JSON if fixture exists
+      if [[ -n "${GH_MOCK_ISSUE_JSON:-}" ]]; then
+        echo "$GH_MOCK_ISSUE_JSON"
+      else
+        echo '{"body":"Source: qte77/test-repo#1","title":"Test issue","number":10}'
+      fi
+      ;;
+    *)
+      echo "UNMOCKED: gh $*" >&2
+      return 1
+      ;;
+  esac
+}
+export -f gh

--- a/tests/unit/test_sync_back.bats
+++ b/tests/unit/test_sync_back.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+
+# Phase 2 TDD: tests for scripts/sync-back.sh
+# Tests reverse sync (tracker → source repo) using mocked gh CLI.
+
+setup() {
+  export TMPDIR="${BATS_TMPDIR:-/tmp/claude-1000/bats-tmp}"
+  export GH_MOCK_LOG="$BATS_TMPDIR/gh_mock_$$.log"
+  rm -f "$GH_MOCK_LOG"
+  source "$BATS_TEST_DIRNAME/../test_helper/gh_mock.bash"
+  source "$BATS_TEST_DIRNAME/../../scripts/common.sh"
+  source "$BATS_TEST_DIRNAME/../../scripts/sync-back.sh"
+}
+
+teardown() {
+  rm -f "$GH_MOCK_LOG"
+}
+
+# Helper: read what gh was called with
+gh_calls() {
+  cat "$GH_MOCK_LOG" 2>/dev/null || echo ""
+}
+
+# --- handle_issue_closed ---
+
+@test "handle_issue_closed closes source issue" {
+  handle_issue_closed "qte77/test-repo#5" "qte77/test-repo"
+  gh_calls | grep -q "gh issue close 5 -R qte77/test-repo"
+}
+
+@test "handle_issue_closed skips tracker-only (empty ref)" {
+  handle_issue_closed "" ""
+  [ ! -f "$GH_MOCK_LOG" ] || [ ! -s "$GH_MOCK_LOG" ]
+}
+
+# --- handle_issue_reopened ---
+
+@test "handle_issue_reopened reopens source issue" {
+  handle_issue_reopened "qte77/test-repo#3" "qte77/test-repo"
+  gh_calls | grep -q "gh issue reopen 3 -R qte77/test-repo"
+}
+
+# --- handle_issue_labeled ---
+
+@test "handle_issue_labeled adds label to source issue" {
+  handle_issue_labeled "qte77/test-repo#7" "qte77/test-repo" "bug"
+  gh_calls | grep -q "gh issue edit 7 -R qte77/test-repo --add-label bug"
+}
+
+# --- handle_issue_unlabeled ---
+
+@test "handle_issue_unlabeled removes label from source issue" {
+  handle_issue_unlabeled "qte77/test-repo#7" "qte77/test-repo" "wontfix"
+  gh_calls | grep -q "gh issue edit 7 -R qte77/test-repo --remove-label wontfix"
+}
+
+# --- handle_issue_edited ---
+
+@test "handle_issue_edited updates source issue title" {
+  handle_issue_edited "qte77/test-repo#2" "qte77/test-repo" "New title"
+  gh_calls | grep -q 'gh issue edit 2 -R qte77/test-repo --title New title'
+}
+
+# --- handle_issue_assigned ---
+
+@test "handle_issue_assigned adds assignee to source issue" {
+  handle_issue_assigned "qte77/test-repo#4" "qte77/test-repo" "octocat"
+  gh_calls | grep -q "gh issue edit 4 -R qte77/test-repo --add-assignee octocat"
+}
+
+# --- handle_issue_unassigned ---
+
+@test "handle_issue_unassigned removes assignee from source issue" {
+  handle_issue_unassigned "qte77/test-repo#4" "qte77/test-repo" "octocat"
+  gh_calls | grep -q "gh issue edit 4 -R qte77/test-repo --remove-assignee octocat"
+}
+
+# --- handle_issue_comment ---
+
+@test "handle_issue_comment adds prefixed comment to source issue" {
+  handle_issue_comment "qte77/test-repo#6" "qte77/test-repo" "Great progress"
+  gh_calls | grep -q "gh issue comment 6 -R qte77/test-repo --body"
+  # Verify prefix
+  gh_calls | grep -q "\[tracker\]"
+}
+
+# --- dispatch_event ---
+
+@test "dispatch_event routes closed action to handle_issue_closed" {
+  dispatch_event "closed" "qte77/test-repo#1" "qte77/test-repo" "" "" ""
+  gh_calls | grep -q "gh issue close 1"
+}
+
+@test "dispatch_event routes reopened action" {
+  dispatch_event "reopened" "qte77/test-repo#1" "qte77/test-repo" "" "" ""
+  gh_calls | grep -q "gh issue reopen 1"
+}
+
+@test "dispatch_event routes labeled action" {
+  dispatch_event "labeled" "qte77/test-repo#1" "qte77/test-repo" "enhancement" "" ""
+  gh_calls | grep -q "gh issue edit 1 -R qte77/test-repo --add-label enhancement"
+}
+
+@test "dispatch_event routes unlabeled action" {
+  dispatch_event "unlabeled" "qte77/test-repo#1" "qte77/test-repo" "stale" "" ""
+  gh_calls | grep -q "gh issue edit 1 -R qte77/test-repo --remove-label stale"
+}
+
+@test "dispatch_event routes edited action with title" {
+  dispatch_event "edited" "qte77/test-repo#1" "qte77/test-repo" "" "Updated title" ""
+  gh_calls | grep -q "gh issue edit 1 -R qte77/test-repo --title Updated title"
+}
+
+@test "dispatch_event routes assigned action" {
+  dispatch_event "assigned" "qte77/test-repo#1" "qte77/test-repo" "" "" "octocat"
+  gh_calls | grep -q "gh issue edit 1 -R qte77/test-repo --add-assignee octocat"
+}
+
+@test "dispatch_event routes unassigned action" {
+  dispatch_event "unassigned" "qte77/test-repo#1" "qte77/test-repo" "" "" "octocat"
+  gh_calls | grep -q "gh issue edit 1 -R qte77/test-repo --remove-assignee octocat"
+}
+
+@test "dispatch_event routes comment created action" {
+  dispatch_event "comment_created" "qte77/test-repo#1" "qte77/test-repo" "" "" "" "Looks good"
+  gh_calls | grep -q "gh issue comment 1"
+}
+
+# --- Guard: tracker-only ---
+
+@test "dispatch_event skips when source ref is empty" {
+  dispatch_event "closed" "" "" "" "" ""
+  [ ! -f "$GH_MOCK_LOG" ] || [ ! -s "$GH_MOCK_LOG" ]
+}
+
+# --- Guard: dry run ---
+
+@test "dispatch_event in dry-run mode does not call gh" {
+  DRY_RUN=true dispatch_event "closed" "qte77/test-repo#1" "qte77/test-repo" "" "" ""
+  [ ! -f "$GH_MOCK_LOG" ] || [ ! -s "$GH_MOCK_LOG" ]
+}


### PR DESCRIPTION
## Summary

- Reverse sync handlers in `scripts/sync-back.sh`
- Mock gh CLI in `tests/test_helper/gh_mock.bash`
- 19 new BATS tests in `tests/unit/test_sync_back.bats`
- TDD Red-Green-Refactor cycle completed

## Handlers

- `handle_issue_closed/reopened` — state sync
- `handle_issue_labeled/unlabeled` — label sync
- `handle_issue_edited` — title sync
- `handle_issue_assigned/unassigned` — assignee sync
- `handle_issue_comment` — comment sync with `[tracker]` prefix
- `dispatch_event` — routes actions with tracker-only + dry-run guards

## Test plan

- [x] 38/38 BATS tests passing (Phase 1 + Phase 2)

Generated with Claude <noreply@anthropic.com>