### PR TITLE
fix: portable grep, unknown action test

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -4,7 +4,7 @@
 # Parse "Source: owner/repo#N" from issue body. Returns the ref or empty.
 parse_source_ref() {
   local body="$1"
-  echo -e "$body" | grep -oP '(?<=Source:\s{0,10})\S+' | head -1
+  echo -e "$body" | sed -n 's/^Source:[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -1
 }
 
 # Extract a component from a source ref (owner/repo#N).

--- a/tests/unit/test_sync_back.bats
+++ b/tests/unit/test_sync_back.bats
@@ -139,3 +139,12 @@ gh_calls() {
   DRY_RUN=true dispatch_event "closed" "qte77/test-repo#1" "qte77/test-repo" "" "" ""
   [ ! -f "$GH_MOCK_LOG" ] || [ ! -s "$GH_MOCK_LOG" ]
 }
+
+# --- Guard: unknown action ---
+
+@test "dispatch_event prints error for unknown action" {
+  run dispatch_event "invalid_action" "qte77/test-repo#1" "qte77/test-repo" "" "" ""
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "Unknown action: invalid_action"
+  [ ! -f "$GH_MOCK_LOG" ] || [ ! -s "$GH_MOCK_LOG" ]
+}


### PR DESCRIPTION
## Summary

- Replace `grep -P` (PCRE) with `sed` in `parse_source_ref` for macOS portability
- Add unknown action test for `dispatch_event`

## Test plan

- [x] 39/39 BATS tests passing

Generated with Claude <noreply@anthropic.com>