### PR TITLE
feat: add sync-forward.sh with TDD tests (Phase 3)

### DIFF
--- a/scripts/sync-forward.sh
+++ b/scripts/sync-forward.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# sync-forward.sh — Forward sync: repo issues → tracker mirrors + markdown.
+# Requires common.sh to be sourced first.
+
+DRY_RUN="${DRY_RUN:-false}"
+TRACKER_REPO="${TRACKER_REPO:-}"
+OWNER="${OWNER:-}"
+
+# Find mirror issue number for a source ref in cached mirror JSON.
+# Args: $1 = source ref, $2 = mirror issues JSON array
+find_mirror_for_ref() {
+  local ref="$1" mirrors="$2"
+  echo "$mirrors" | jq -r --arg ref "$ref" \
+    '.[] | select(.body | contains($ref)) | .number' 2>/dev/null | head -1
+}
+
+# Get mirror state for a source ref.
+_mirror_state() {
+  local ref="$1" mirrors="$2"
+  echo "$mirrors" | jq -r --arg ref "$ref" \
+    '.[] | select(.body | contains($ref)) | .state' 2>/dev/null | head -1
+}
+
+# Get mirror title for a source ref.
+_mirror_title() {
+  local ref="$1" mirrors="$2"
+  echo "$mirrors" | jq -r --arg ref "$ref" \
+    '.[] | select(.body | contains($ref)) | .title' 2>/dev/null | head -1
+}
+
+# Get comma-separated labels from mirror.
+_mirror_labels() {
+  local ref="$1" mirrors="$2"
+  echo "$mirrors" | jq -r --arg ref "$ref" \
+    '.[] | select(.body | contains($ref)) | [.labels[].name] | join(",")' 2>/dev/null | head -1
+}
+
+# Get comma-separated assignees from mirror.
+_mirror_assignees() {
+  local ref="$1" mirrors="$2"
+  echo "$mirrors" | jq -r --arg ref "$ref" \
+    '.[] | select(.body | contains($ref)) | [.assignees[].login] | join(",")' 2>/dev/null | head -1
+}
+
+create_mirror() {
+  local repo="$1" title="$2" ref="$3"
+  local mirror_title mirror_body
+  mirror_title="$(build_mirror_title "$repo" "$title")"
+  mirror_body="$(build_mirror_body "$ref")"
+  gh issue create -R "$TRACKER_REPO" \
+    --title "$mirror_title" \
+    --body "$mirror_body" \
+    --label "$repo"
+}
+
+close_mirror() {
+  local mirror_num="$1"
+  gh issue close "$mirror_num" -R "$TRACKER_REPO"
+}
+
+reopen_mirror() {
+  local mirror_num="$1"
+  gh issue reopen "$mirror_num" -R "$TRACKER_REPO"
+}
+
+update_mirror_title() {
+  local mirror_num="$1" new_title="$2"
+  gh issue edit "$mirror_num" -R "$TRACKER_REPO" --title "$new_title"
+}
+
+# Check if a value exists in a comma-separated list.
+_in_csv() {
+  local needle="$1" haystack="$2"
+  [[ ",$haystack," == *",$needle,"* ]]
+}
+
+# Sync labels between source and mirror.
+# Args: mirror_num source_labels mirror_labels [repo_label]
+# Labels are comma-separated strings.
+sync_mirror_labels() {
+  local mirror_num="$1" src_labels="$2" mir_labels="$3" repo_label="${4:-}"
+
+  # Add missing labels
+  while IFS= read -r label; do
+    [[ -z "$label" ]] && continue
+    _in_csv "$label" "$mir_labels" || gh issue edit "$mirror_num" -R "$TRACKER_REPO" --add-label "$label"
+  done <<< "${src_labels//,/$'\n'}"
+
+  # Remove extra labels (skip repo label)
+  while IFS= read -r label; do
+    [[ -z "$label" || "$label" == "$repo_label" ]] && continue
+    _in_csv "$label" "$src_labels" || gh issue edit "$mirror_num" -R "$TRACKER_REPO" --remove-label "$label"
+  done <<< "${mir_labels//,/$'\n'}"
+}
+
+# Sync assignees between source and mirror.
+# Args: mirror_num source_assignees mirror_assignees
+sync_mirror_assignees() {
+  local mirror_num="$1" src_assignees="$2" mir_assignees="$3"
+
+  while IFS= read -r assignee; do
+    [[ -z "$assignee" ]] && continue
+    _in_csv "$assignee" "$mir_assignees" || gh issue edit "$mirror_num" -R "$TRACKER_REPO" --add-assignee "$assignee"
+  done <<< "${src_assignees//,/$'\n'}"
+
+  while IFS= read -r assignee; do
+    [[ -z "$assignee" ]] && continue
+    _in_csv "$assignee" "$src_assignees" || gh issue edit "$mirror_num" -R "$TRACKER_REPO" --remove-assignee "$assignee"
+  done <<< "${mir_assignees//,/$'\n'}"
+}
+
+# Sync a single repo's issues to tracker mirrors.
+# Args: $1 = repo name
+sync_repo() {
+  local repo="$1"
+
+  # Fetch source issues
+  local source_json
+  source_json="$(gh issue list -R "$OWNER/$repo" --state all --limit 200 \
+    --json number,title,state,labels,assignees 2>/dev/null || echo "[]")"
+
+  # Fetch existing mirrors
+  local mirror_json
+  mirror_json="$(gh issue list -R "$TRACKER_REPO" --state all --limit 500 \
+    --json number,title,body,state,labels,assignees 2>/dev/null || echo "[]")"
+
+  # Process each source issue
+  while IFS= read -r issue; do
+    local src_num src_title src_state src_ref
+    src_num="$(echo "$issue" | jq -r '.number')"
+    src_title="$(echo "$issue" | jq -r '.title')"
+    src_state="$(echo "$issue" | jq -r '.state')"
+    src_ref="$OWNER/$repo#$src_num"
+
+    local mirror_num
+    mirror_num="$(find_mirror_for_ref "$src_ref" "$mirror_json")"
+    local mirror_state
+    mirror_state="$(_mirror_state "$src_ref" "$mirror_json")"
+
+    if [[ "$src_state" == "OPEN" ]]; then
+      if [[ -z "$mirror_num" ]]; then
+        # New issue — create mirror
+        if [[ "$DRY_RUN" == "true" ]]; then
+          echo "[dry-run] Would create mirror: [$repo] $src_title"
+        else
+          create_mirror "$repo" "$src_title" "$src_ref"
+        fi
+      else
+        # Existing mirror — sync state and metadata
+        [[ "$mirror_state" == "CLOSED" && "$DRY_RUN" != "true" ]] && reopen_mirror "$mirror_num"
+
+        # Sync title
+        local expected_title
+        expected_title="$(build_mirror_title "$repo" "$src_title")"
+        local current_title
+        current_title="$(_mirror_title "$src_ref" "$mirror_json")"
+        [[ "$current_title" != "$expected_title" && "$DRY_RUN" != "true" ]] && \
+          update_mirror_title "$mirror_num" "$expected_title"
+
+        # Sync labels
+        if [[ "$DRY_RUN" != "true" ]]; then
+          local src_labels mir_labels
+          src_labels="$(echo "$issue" | jq -r '[.labels[].name] | join(",")')"
+          mir_labels="$(_mirror_labels "$src_ref" "$mirror_json")"
+          sync_mirror_labels "$mirror_num" "$src_labels" "$mir_labels" "$repo"
+        fi
+
+        # Sync assignees
+        if [[ "$DRY_RUN" != "true" ]]; then
+          local src_assignees mir_assignees
+          src_assignees="$(echo "$issue" | jq -r '[.assignees[].login] | join(",")')"
+          mir_assignees="$(_mirror_assignees "$src_ref" "$mirror_json")"
+          sync_mirror_assignees "$mirror_num" "$src_assignees" "$mir_assignees"
+        fi
+      fi
+    elif [[ "$src_state" == "CLOSED" ]]; then
+      if [[ -n "$mirror_num" && "$mirror_state" == "OPEN" ]]; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+          echo "[dry-run] Would close mirror #$mirror_num"
+        else
+          close_mirror "$mirror_num"
+        fi
+      fi
+    fi
+  done < <(echo "$source_json" | jq -c '.[]')
+}
+
+# Generate TODO.md and DONE.md from issues JSON.
+# Args: $1 = output dir, $2 = repo name (empty = tracker-only), $3 = issues JSON
+generate_markdown() {
+  local out_dir="$1" repo="$2" issues_json="$3"
+  local timestamp
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  local section_header=""
+  [[ -n "$repo" ]] && section_header="## $repo"
+
+  # Open issues → TODO.md
+  local open_md
+  if [[ -n "$repo" ]]; then
+    open_md="$(echo "$issues_json" | jq -r \
+      '.[] | select(.state == "OPEN") | "- [ ] \(.title) (#\(.number))"')"
+  else
+    # Tracker-only: filter issues without Source ref in body
+    open_md="$(echo "$issues_json" | jq -r \
+      '.[] | select(.state == "OPEN") | select(.body | contains("Source:") | not) | "- [ ] \(.title) (#\(.number))"')"
+    section_header="## tracker"
+  fi
+
+  if [[ -n "$open_md" ]]; then
+    if [[ -f "$out_dir/TODO.md" ]]; then
+      echo -e "\n$section_header\n\n$open_md" >> "$out_dir/TODO.md"
+    else
+      echo -e "# TODO\n\n_Last sync: ${timestamp}_\n\n$section_header\n\n$open_md" > "$out_dir/TODO.md"
+    fi
+  fi
+
+  # Closed issues → DONE.md
+  local closed_md
+  if [[ -n "$repo" ]]; then
+    closed_md="$(echo "$issues_json" | jq -r \
+      '.[] | select(.state == "CLOSED") | "- [x] \(.title) (#\(.number))"')"
+  else
+    closed_md="$(echo "$issues_json" | jq -r \
+      '.[] | select(.state == "CLOSED") | select(.body | contains("Source:") | not) | "- [x] \(.title) (#\(.number))"')"
+  fi
+
+  if [[ -n "$closed_md" ]]; then
+    if [[ -f "$out_dir/DONE.md" ]]; then
+      echo -e "\n$section_header\n\n$closed_md" >> "$out_dir/DONE.md"
+    else
+      echo -e "# DONE\n\n_Last sync: ${timestamp}_\n\n$section_header\n\n$closed_md" > "$out_dir/DONE.md"
+    fi
+  fi
+}

--- a/tests/fixtures/mirror_issues.json
+++ b/tests/fixtures/mirror_issues.json
@@ -1,0 +1,5 @@
+[
+  {"number":10,"title":"[test-repo] Fix login bug","body":"Source: qte77/test-repo#1","state":"OPEN","labels":[{"name":"bug"},{"name":"test-repo"}],"assignees":[{"login":"octocat"}]},
+  {"number":11,"title":"[test-repo] Old feature","body":"Source: qte77/test-repo#3","state":"OPEN","labels":[],"assignees":[]},
+  {"number":20,"title":"Private planning task","body":"Internal tracker task","state":"OPEN","labels":[],"assignees":[]}
+]

--- a/tests/fixtures/source_issues.json
+++ b/tests/fixtures/source_issues.json
@@ -1,0 +1,5 @@
+[
+  {"number":1,"title":"Fix login bug","state":"OPEN","labels":[{"name":"bug"}],"assignees":[{"login":"octocat"}]},
+  {"number":2,"title":"Add dark mode","state":"OPEN","labels":[],"assignees":[]},
+  {"number":3,"title":"Old feature","state":"CLOSED","labels":[{"name":"done"}],"assignees":[]}
+]

--- a/tests/test_helper/gh_mock.bash
+++ b/tests/test_helper/gh_mock.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # gh_mock.bash — Mock gh CLI for BATS tests.
 # Records calls to GH_MOCK_LOG for assertion. Returns canned responses.
+# Set GH_MOCK_SOURCE_JSON / GH_MOCK_MIRROR_JSON for issue list responses.
 
 export GH_MOCK_LOG="${GH_MOCK_LOG:-$BATS_TMPDIR/gh_mock.log}"
 
@@ -8,18 +9,30 @@ gh() {
   echo "gh $*" >> "$GH_MOCK_LOG"
 
   case "$1 $2" in
-    "issue close")   echo "" ;;
-    "issue reopen")  echo "" ;;
-    "issue edit")    echo "" ;;
+    "issue list")
+      # Detect which repo is being queried via -R flag
+      local args="$*"
+      if [[ "$args" == *"$GH_MOCK_TRACKER_REPO"* && -n "${GH_MOCK_MIRROR_JSON:-}" ]]; then
+        echo "$GH_MOCK_MIRROR_JSON"
+      elif [[ -n "${GH_MOCK_SOURCE_JSON:-}" ]]; then
+        echo "$GH_MOCK_SOURCE_JSON"
+      else
+        echo "[]"
+      fi
+      ;;
+    "issue create") echo "https://github.com/mock/repo/issues/99" ;;
+    "issue close")  echo "" ;;
+    "issue reopen") echo "" ;;
+    "issue edit")   echo "" ;;
     "issue comment") echo "" ;;
     "issue view")
-      # Return canned issue JSON if fixture exists
       if [[ -n "${GH_MOCK_ISSUE_JSON:-}" ]]; then
         echo "$GH_MOCK_ISSUE_JSON"
       else
         echo '{"body":"Source: qte77/test-repo#1","title":"Test issue","number":10}'
       fi
       ;;
+    "project item-add") echo "" ;;
     *)
       echo "UNMOCKED: gh $*" >&2
       return 1

--- a/tests/unit/test_sync_forward.bats
+++ b/tests/unit/test_sync_forward.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+
+# Phase 3 TDD: tests for scripts/sync-forward.sh
+# Tests forward sync (repo issues → tracker mirrors + markdown).
+
+FIXTURES="$BATS_TEST_DIRNAME/../fixtures"
+
+setup() {
+  export TMPDIR="${BATS_TMPDIR:-/tmp/claude-1000/bats-tmp}"
+  export GH_MOCK_LOG="$BATS_TMPDIR/gh_mock_$$.log"
+  export GH_MOCK_TRACKER_REPO="qte77/.github-private-project-tracker"
+  export TRACKER_REPO="$GH_MOCK_TRACKER_REPO"
+  export OWNER="qte77"
+  export MARKDOWN_DIR="$BATS_TMPDIR/md_$$"
+  mkdir -p "$MARKDOWN_DIR"
+  rm -f "$GH_MOCK_LOG"
+
+  export GH_MOCK_SOURCE_JSON="$(cat "$FIXTURES/source_issues.json")"
+  export GH_MOCK_MIRROR_JSON="$(cat "$FIXTURES/mirror_issues.json")"
+
+  source "$BATS_TEST_DIRNAME/../test_helper/gh_mock.bash"
+  source "$BATS_TEST_DIRNAME/../../scripts/common.sh"
+  source "$BATS_TEST_DIRNAME/../../scripts/sync-forward.sh"
+}
+
+teardown() {
+  rm -f "$GH_MOCK_LOG"
+  rm -rf "$MARKDOWN_DIR"
+}
+
+gh_calls() {
+  cat "$GH_MOCK_LOG" 2>/dev/null || echo ""
+}
+
+# --- find_mirror_for_ref ---
+
+@test "find_mirror_for_ref returns mirror number when match exists" {
+  result="$(find_mirror_for_ref "qte77/test-repo#1" "$GH_MOCK_MIRROR_JSON")"
+  [ "$result" = "10" ]
+}
+
+@test "find_mirror_for_ref returns empty when no match" {
+  result="$(find_mirror_for_ref "qte77/test-repo#999" "$GH_MOCK_MIRROR_JSON")"
+  [ -z "$result" ]
+}
+
+# --- create_mirror ---
+
+@test "create_mirror calls gh issue create with correct title and body" {
+  create_mirror "test-repo" "Fix login bug" "qte77/test-repo#1"
+  gh_calls | grep -q "gh issue create"
+  gh_calls | grep -q "\[test-repo\] Fix login bug"
+  gh_calls | grep -q "Source: qte77/test-repo#1"
+}
+
+@test "create_mirror adds repo as label" {
+  create_mirror "test-repo" "Fix login bug" "qte77/test-repo#1"
+  gh_calls | grep -q "\-\-label test-repo"
+}
+
+# --- close_mirror ---
+
+@test "close_mirror calls gh issue close on mirror number" {
+  close_mirror 10
+  gh_calls | grep -q "gh issue close 10"
+}
+
+# --- reopen_mirror ---
+
+@test "reopen_mirror calls gh issue reopen on mirror number" {
+  reopen_mirror 11
+  gh_calls | grep -q "gh issue reopen 11"
+}
+
+# --- update_mirror_title ---
+
+@test "update_mirror_title calls gh issue edit with new title" {
+  update_mirror_title 10 "[test-repo] New title"
+  gh_calls | grep -q "gh issue edit 10"
+  gh_calls | grep -q "\-\-title"
+}
+
+# --- sync_mirror_labels ---
+
+@test "sync_mirror_labels adds missing labels" {
+  sync_mirror_labels 10 "bug,enhancement" "bug"
+  gh_calls | grep -q "\-\-add-label enhancement"
+}
+
+@test "sync_mirror_labels removes extra labels, skips repo label" {
+  sync_mirror_labels 10 "bug" "bug,stale" "test-repo"
+  gh_calls | grep -q "\-\-remove-label stale"
+  # Should NOT remove the repo label
+  ! gh_calls | grep -q "\-\-remove-label test-repo"
+}
+
+@test "sync_mirror_labels no-ops when labels match" {
+  sync_mirror_labels 10 "bug" "bug"
+  [ ! -f "$GH_MOCK_LOG" ] || ! gh_calls | grep -q "issue edit"
+}
+
+# --- sync_mirror_assignees ---
+
+@test "sync_mirror_assignees adds missing assignees" {
+  sync_mirror_assignees 10 "octocat,alice" "octocat"
+  gh_calls | grep -q "\-\-add-assignee alice"
+}
+
+@test "sync_mirror_assignees removes extra assignees" {
+  sync_mirror_assignees 10 "octocat" "octocat,bob"
+  gh_calls | grep -q "\-\-remove-assignee bob"
+}
+
+@test "sync_mirror_assignees no-ops when assignees match" {
+  sync_mirror_assignees 10 "octocat" "octocat"
+  [ ! -f "$GH_MOCK_LOG" ] || ! gh_calls | grep -q "issue edit"
+}
+
+# --- sync_repo ---
+
+@test "sync_repo creates mirror for new open issue" {
+  sync_repo "test-repo"
+  # Issue #2 (Add dark mode) has no mirror → should create
+  gh_calls | grep -q "gh issue create"
+  gh_calls | grep -q "\[test-repo\] Add dark mode"
+}
+
+@test "sync_repo closes mirror for closed source issue" {
+  sync_repo "test-repo"
+  # Issue #3 (Old feature) is CLOSED, mirror #11 is OPEN → should close
+  gh_calls | grep -q "gh issue close 11"
+}
+
+@test "sync_repo does not recreate existing mirror" {
+  sync_repo "test-repo"
+  # Issue #1 already has mirror #10 → should NOT create
+  local create_count
+  create_count="$(gh_calls | grep -c "gh issue create" || echo 0)"
+  # Only 1 create (for issue #2), not 2
+  [ "$create_count" -eq 1 ]
+}
+
+# --- sync_repo dry run ---
+
+@test "sync_repo in dry-run does not call gh issue create/close" {
+  DRY_RUN=true sync_repo "test-repo"
+  [ ! -f "$GH_MOCK_LOG" ] || ! gh_calls | grep -q "gh issue create"
+  [ ! -f "$GH_MOCK_LOG" ] || ! gh_calls | grep -q "gh issue close"
+}
+
+# --- generate_markdown ---
+
+@test "generate_markdown writes TODO.md with open issues" {
+  generate_markdown "$MARKDOWN_DIR" "test-repo" "$GH_MOCK_SOURCE_JSON"
+  [ -f "$MARKDOWN_DIR/TODO.md" ]
+  grep -q "Fix login bug" "$MARKDOWN_DIR/TODO.md"
+  grep -q "Add dark mode" "$MARKDOWN_DIR/TODO.md"
+}
+
+@test "generate_markdown writes DONE.md with closed issues" {
+  generate_markdown "$MARKDOWN_DIR" "test-repo" "$GH_MOCK_SOURCE_JSON"
+  [ -f "$MARKDOWN_DIR/DONE.md" ]
+  grep -q "Old feature" "$MARKDOWN_DIR/DONE.md"
+}
+
+@test "generate_markdown TODO.md does not include closed issues" {
+  generate_markdown "$MARKDOWN_DIR" "test-repo" "$GH_MOCK_SOURCE_JSON"
+  ! grep -q "Old feature" "$MARKDOWN_DIR/TODO.md"
+}
+
+@test "generate_markdown includes tracker-only issues in TODO.md" {
+  generate_markdown "$MARKDOWN_DIR" "" "$GH_MOCK_MIRROR_JSON"
+  grep -q "Private planning task" "$MARKDOWN_DIR/TODO.md"
+}


### PR DESCRIPTION
## Summary

- Forward sync in `scripts/sync-forward.sh`
- Updated `tests/test_helper/gh_mock.bash` with richer mock responses
- Test fixtures in `tests/fixtures/` for source + mirror issue JSON
- 21 new BATS tests in `tests/unit/test_sync_forward.bats`
- TDD Red-Green-Refactor cycle completed

## Functions

- `find_mirror_for_ref` — lookup mirror by source ref
- `create/close/reopen_mirror` — mirror lifecycle
- `update_mirror_title` — title sync
- `sync_mirror_labels` — diff-based label sync (skips repo label)
- `sync_mirror_assignees` — diff-based assignee sync
- `sync_repo` — per-repo sync orchestrator with dry-run
- `generate_markdown` — TODO.md/DONE.md with tracker-only support

## Test plan

- [x] 60/60 BATS tests passing (Phase 1 + 2 + 3)

Generated with Claude <noreply@anthropic.com>