### PR TITLE
feat: add action.yml, README, LICENSE (Phase 4)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 qte77
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,119 @@
 # gha-cross-repo-issue-sync
+
+Bidirectional GitHub issue sync across repos. Composite GitHub Action.
+
+- **Forward sync**: repo issues → tracker mirror issues + TODO.md/DONE.md
+- **Reverse sync**: tracker issue events → source repo (close, reopen, labels, assignees, title, comments)
+- **Tracker-only issues**: private tasks visible only in the tracker repo
+
+## Usage
+
+### Forward sync (scheduled)
+
+```yaml
+# .github/workflows/sync-forward.yml
+name: Forward sync
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+permissions:
+  contents: write
+  issues: write
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: qte77/gha-cross-repo-issue-sync@v1
+        with:
+          direction: forward
+          tracker_repo: owner/.github-private-project-tracker
+          repos_file: repos.txt
+          token: ${{ secrets.PROJECT_TRACKER_PAT }}
+      - name: Commit markdown
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add TODO.md DONE.md
+          git diff --cached --quiet && exit 0
+          git commit -m "chore: sync TODO/DONE"
+          git push
+```
+
+### Reverse sync (event-driven)
+
+```yaml
+# .github/workflows/sync-back.yml
+name: Reverse sync
+on:
+  issues:
+    types: [closed, reopened, edited, labeled, unlabeled, assigned, unassigned]
+  issue_comment:
+    types: [created]
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - uses: qte77/gha-cross-repo-issue-sync@v1
+        with:
+          direction: reverse
+          tracker_repo: ${{ github.repository }}
+          token: ${{ secrets.PROJECT_TRACKER_PAT }}
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `direction` | Yes | — | `forward`, `reverse`, or `both` |
+| `tracker_repo` | Yes | — | Tracker repo (`owner/repo`) |
+| `repos_file` | No | `repos.txt` | File listing tracked repos |
+| `repos` | No | — | Comma-separated repo list (alternative to file) |
+| `owner` | No | `github.repository_owner` | GitHub owner for tracked repos |
+| `token` | Yes | `github.token` | PAT with Issues read+write |
+| `project_id` | No | — | GitHub Projects board ID |
+| `generate_markdown` | No | `true` | Generate TODO.md/DONE.md |
+| `dry_run` | No | `false` | Preview without changes |
+
+## How it works
+
+```
+Source repos (issues = SOT)
+    ↕ bidirectional sync
+Tracker repo (mirror issues + TODO.md + DONE.md)
+```
+
+**Forward** (batch, scheduled): reads issues from all repos, creates/closes/updates mirrors, generates markdown.
+
+**Reverse** (event-driven, instant): fires on issue events in the tracker repo, propagates state changes back to source repos via `Source: owner/repo#N` reference in the mirror issue body.
+
+**Loop prevention**: bot actor check + comment prefix guards (`[source]`, `[tracker]`, `[sync-bot]`).
+
+**Tracker-only issues**: issues without a `Source:` ref are private to the tracker — visible in TODO.md under `## tracker`, ignored by reverse sync.
+
+## PAT requirements
+
+| Scope | Why |
+|---|---|
+| Issues (read+write) on tracked repos | Forward: read. Reverse: write. |
+| Issues (read+write) on tracker repo | Forward: create/edit mirrors |
+| Contents (write) on tracker repo | Commit TODO.md/DONE.md |
+| `read:org` + `project` (classic, optional) | Projects board aggregation |
+
+## Development
+
+```bash
+# Run all tests
+bats tests/unit/
+
+# Run specific phase
+bats tests/unit/test_common.bats
+bats tests/unit/test_sync_back.bats
+bats tests/unit/test_sync_forward.bats
+```
+
+## License
+
+MIT

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,170 @@
+name: 'Cross-Repo Issue Sync'
+description: 'Bidirectional GitHub issue sync across repos with mirror issues, markdown generation, and Projects board aggregation.'
+author: 'qte77'
+
+branding:
+  icon: 'refresh-cw'
+  color: 'blue'
+
+inputs:
+  direction:
+    description: 'Sync direction: forward, reverse, or both'
+    required: true
+  tracker_repo:
+    description: 'Tracker repo (e.g. owner/.github-private-project-tracker)'
+    required: true
+  repos_file:
+    description: 'Path to repos.txt (one repo name per line). Used for forward sync.'
+    required: false
+    default: 'repos.txt'
+  repos:
+    description: 'Comma-separated repo list (alternative to repos_file). Used for forward sync.'
+    required: false
+  owner:
+    description: 'GitHub owner/org for tracked repos'
+    required: false
+    default: ${{ github.repository_owner }}
+  token:
+    description: 'GitHub token with Issues read+write on all repos'
+    required: true
+    default: ${{ github.token }}
+  project_id:
+    description: 'GitHub Projects board ID. If set, adds issues to the board.'
+    required: false
+  generate_markdown:
+    description: 'Generate TODO.md and DONE.md in the working directory'
+    required: false
+    default: 'true'
+  dry_run:
+    description: 'Preview without making changes'
+    required: false
+    default: 'false'
+  event_action:
+    description: 'Issue event action (for reverse sync). Auto-set from github.event.action.'
+    required: false
+    default: ${{ github.event.action }}
+  event_issue_number:
+    description: 'Issue number that triggered the event (for reverse sync).'
+    required: false
+    default: ''
+  event_label:
+    description: 'Label name from the event (for labeled/unlabeled).'
+    required: false
+    default: ''
+  event_assignee:
+    description: 'Assignee login from the event (for assigned/unassigned).'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Forward sync
+      if: inputs.direction == 'forward' || inputs.direction == 'both'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        TRACKER_REPO: ${{ inputs.tracker_repo }}
+        OWNER: ${{ inputs.owner }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        REPOS_FILE: ${{ inputs.repos_file }}
+        REPOS_CSV: ${{ inputs.repos }}
+        GENERATE_MARKDOWN: ${{ inputs.generate_markdown }}
+        PROJECT_ID: ${{ inputs.project_id }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        source "$ACTION_PATH/scripts/common.sh"
+        source "$ACTION_PATH/scripts/sync-forward.sh"
+
+        # Build repo list
+        repos=()
+        if [[ -n "$REPOS_CSV" ]]; then
+          IFS=',' read -ra repos <<< "$REPOS_CSV"
+        elif [[ -f "$REPOS_FILE" ]]; then
+          mapfile -t repos < <(grep -v '^\s*#' "$REPOS_FILE" | grep -v '^\s*$' | xargs -L1)
+        fi
+
+        if [[ ${#repos[@]} -eq 0 ]]; then
+          echo "::warning::No repos to sync. Set repos_file or repos input."
+          exit 0
+        fi
+
+        # Sync each repo
+        for repo in "${repos[@]}"; do
+          echo "--- $repo ---"
+          sync_repo "$repo"
+        done
+
+        # Generate markdown
+        if [[ "$GENERATE_MARKDOWN" == "true" ]]; then
+          # Fetch all tracker issues for markdown (mirrors + tracker-only)
+          tracker_json="$(gh issue list -R "$TRACKER_REPO" --state all --limit 500 \
+            --json number,title,body,state 2>/dev/null || echo "[]")"
+
+          for repo in "${repos[@]}"; do
+            repo_json="$(gh issue list -R "$OWNER/$repo" --state all --limit 200 \
+              --json number,title,state 2>/dev/null || echo "[]")"
+            generate_markdown "." "$repo" "$repo_json"
+          done
+
+          # Tracker-only issues
+          generate_markdown "." "" "$tracker_json"
+        fi
+
+        echo "Forward sync complete."
+
+    - name: Reverse sync
+      if: inputs.direction == 'reverse' || inputs.direction == 'both'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        TRACKER_REPO: ${{ inputs.tracker_repo }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        EVENT_ACTION: ${{ inputs.event_action }}
+        EVENT_ISSUE_NUMBER: ${{ inputs.event_issue_number }}
+        EVENT_LABEL: ${{ inputs.event_label }}
+        EVENT_ASSIGNEE: ${{ inputs.event_assignee }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        source "$ACTION_PATH/scripts/common.sh"
+        source "$ACTION_PATH/scripts/sync-back.sh"
+
+        # Loop guard
+        if is_loop "$GITHUB_ACTOR" ""; then
+          echo "Skipping: event from bot actor ($GITHUB_ACTOR)"
+          exit 0
+        fi
+
+        # Get issue body to extract source ref
+        issue_num="${EVENT_ISSUE_NUMBER:-${{ github.event.issue.number }}}"
+        if [[ -z "$issue_num" ]]; then
+          echo "::warning::No issue number in event. Skipping reverse sync."
+          exit 0
+        fi
+
+        issue_body="$(gh issue view "$issue_num" -R "$TRACKER_REPO" --json body --jq '.body' 2>/dev/null || echo "")"
+        source_ref="$(parse_source_ref "$issue_body")"
+
+        if [[ -z "$source_ref" ]]; then
+          echo "Tracker-only issue #$issue_num. Skipping reverse sync."
+          exit 0
+        fi
+
+        repo="$(_issue_repo "$source_ref")"
+        title="${{ github.event.issue.title }}"
+
+        # Strip [repo] prefix from mirror title for edited events
+        if [[ "$EVENT_ACTION" == "edited" ]]; then
+          title="$(echo "$title" | sed 's/^\[[^]]*\] //')"
+        fi
+
+        # Map event action
+        action="$EVENT_ACTION"
+        [[ "$action" == "created" ]] && action="comment_created"
+
+        comment="${{ github.event.comment.body }}"
+
+        dispatch_event "$action" "$source_ref" "$repo" "$EVENT_LABEL" "$title" "$EVENT_ASSIGNEE" "$comment"
+
+        echo "Reverse sync complete for $source_ref ($action)."


### PR DESCRIPTION
## Summary

- `action.yml`: composite action wiring forward + reverse sync
- `README.md`: usage examples, inputs table, architecture, PAT requirements
- `LICENSE`: MIT

## Inputs

direction, tracker_repo, repos_file, repos, owner, token, project_id, generate_markdown, dry_run

## Test plan

- [x] 60/60 BATS tests passing

Generated with Claude <noreply@anthropic.com>