### PR TITLE
fix: sanitize event inputs, add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [Unreleased]
+
+---
+
+## [0.1.0] - 2026-03-23
+
+### Added
+
+- `common.sh`: source ref parsing, loop guards, mirror title/body builders
+- `sync-back.sh`: reverse sync (close, reopen, labels, assignees, title, comments)
+- `sync-forward.sh`: forward sync with mirror lifecycle, diff-based label/assignee sync, markdown generation
+- `action.yml`: composite action with forward/reverse/both directions
+- Repo infra: CodeQL, dependabot, bump-and-release, BATS CI, issue/PR templates
+- 77 BATS unit tests

--- a/action.yml
+++ b/action.yml
@@ -125,6 +125,9 @@ runs:
         EVENT_LABEL: ${{ inputs.event_label }}
         EVENT_ASSIGNEE: ${{ inputs.event_assignee }}
         GITHUB_ACTOR: ${{ github.actor }}
+        EVENT_ISSUE_NUMBER_FALLBACK: ${{ github.event.issue.number }}
+        EVENT_TITLE: ${{ github.event.issue.title }}
+        EVENT_COMMENT: ${{ github.event.comment.body }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
         source "$ACTION_PATH/scripts/common.sh"
@@ -137,7 +140,7 @@ runs:
         fi
 
         # Get issue body to extract source ref
-        issue_num="${EVENT_ISSUE_NUMBER:-${{ github.event.issue.number }}}"
+        issue_num="${EVENT_ISSUE_NUMBER:-$EVENT_ISSUE_NUMBER_FALLBACK}"
         if [[ -z "$issue_num" ]]; then
           echo "::warning::No issue number in event. Skipping reverse sync."
           exit 0
@@ -152,7 +155,7 @@ runs:
         fi
 
         repo="$(_issue_repo "$source_ref")"
-        title="${{ github.event.issue.title }}"
+        title="$EVENT_TITLE"
 
         # Strip [repo] prefix from mirror title for edited events
         if [[ "$EVENT_ACTION" == "edited" ]]; then
@@ -163,7 +166,7 @@ runs:
         action="$EVENT_ACTION"
         [[ "$action" == "created" ]] && action="comment_created"
 
-        comment="${{ github.event.comment.body }}"
+        comment="$EVENT_COMMENT"
 
         dispatch_event "$action" "$source_ref" "$repo" "$EVENT_LABEL" "$title" "$EVENT_ASSIGNEE" "$comment"
 


### PR DESCRIPTION
## Summary

- Move `github.event.issue.title` and `github.event.comment.body` to `env:` block (command injection prevention)
- Add CHANGELOG.md (Keep a Changelog format)

## Test plan

- [x] 77/77 BATS tests passing

Generated with Claude <noreply@anthropic.com>