### PR TITLE
chore: add .editorconfig, SECURITY.md, .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{sh,bash,bats}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.sh text eol=lf
+*.bats text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.json text eol=lf

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately via [GitHub Security Advisories](https://github.com/qte77/gha-cross-repo-issue-sync/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.
+
+## Scope
+
+This action handles GitHub PATs and issue data. Key security considerations:
+
+- **Token scope**: use minimum required permissions (Issues read+write)
+- **Loop prevention**: bot actor + comment prefix guards prevent infinite sync loops
+- **Event input sanitization**: all `github.event.*` data is passed via `env:` blocks, not inline in `run:` commands


### PR DESCRIPTION
## Summary

- `.editorconfig` — consistent formatting (2-space indent for sh/yaml/bats)
- `SECURITY.md` — vulnerability reporting policy + scope
- `.gitattributes` — LF line ending normalization

## Test plan

- [x] 77/77 BATS tests passing

Generated with Claude <noreply@anthropic.com>