### PR TITLE
fix: unset GITHUB_TOKEN so PAT takes precedence

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -63,6 +63,7 @@ runs:
       if: inputs.direction == 'forward' || inputs.direction == 'both'
       shell: bash
       env:
+        GITHUB_TOKEN: ''
         GH_TOKEN: ${{ inputs.token }}
         TRACKER_REPO: ${{ inputs.tracker_repo }}
         OWNER: ${{ inputs.owner }}
@@ -117,6 +118,7 @@ runs:
       if: inputs.direction == 'reverse' || inputs.direction == 'both'
       shell: bash
       env:
+        GITHUB_TOKEN: ''
         GH_TOKEN: ${{ inputs.token }}
         TRACKER_REPO: ${{ inputs.tracker_repo }}
         DRY_RUN: ${{ inputs.dry_run }}

--- a/tests/unit/test_infra_files.bats
+++ b/tests/unit/test_infra_files.bats
@@ -19,6 +19,13 @@ setup() {
   grep -q "color:" "$REPO_ROOT/action.yaml"
 }
 
+@test "action.yaml unsets GITHUB_TOKEN so PAT takes precedence" {
+  # gh CLI resolves GITHUB_TOKEN > GH_TOKEN; must unset in GHA
+  local count
+  count="$(grep -c "GITHUB_TOKEN: ''" "$REPO_ROOT/action.yaml")"
+  [ "$count" -eq 2 ]
+}
+
 # --- dependabot ---
 
 @test "dependabot.yml exists and covers github-actions ecosystem" {


### PR DESCRIPTION
## Summary

`gh` CLI resolves `GITHUB_TOKEN` > `GH_TOKEN`. In GHA, `GITHUB_TOKEN` is always set with current-repo-only scopes. Unsetting it ensures the user-provided PAT is used for cross-repo issue operations.

## Test plan

- [x] TDD: RED (test failed without fix) → GREEN (78 tests passing)
- [ ] Verify mirror issue creation after merge

Generated with Claude <noreply@anthropic.com>