### PR TITLE
docs: add Projects API limitations and verified references

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,16 @@ Tracker repo (mirror issues + TODO.md + DONE.md)
 
 **Tracker-only issues**: issues without a `Source:` ref are private to the tracker — visible in TODO.md under `## tracker`, ignored by reverse sync.
 
-**GitHub Projects board**: use the built-in [auto-add workflow][gh-auto-add] to import issues from the tracker repo into a Kanban board. The board auto-reflects issue state (close → Done) but dragging cards does NOT change issue state — the GHA reverse sync handles that direction.
+**GitHub Projects board**: use the built-in [auto-add workflow][gh-auto-add] to import tracker issues into a Kanban board. The board reflects issue state (close → Done) but dragging cards does NOT change issue state — the GHA reverse sync handles that direction. See [adding items to projects][gh-add-items] for bulk import options.
+
+**Projects API limitations**: fine-grained PATs [do not support user-owned projects][gh-pat-projects] — only org-owned projects via [REST API][gh-projects-rest]. For user-owned projects, use the UI auto-add workflow or a [classic PAT with `project` scope][gh-pat-classic]. See [fine-grained PAT feature gaps][gh-pat-ga] for current status.
 
 [gh-auto-add]: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically
+[gh-add-items]: https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-items-in-your-project/adding-items-to-your-project
+[gh-pat-projects]: https://github.com/actions/add-to-project/issues/289#issuecomment-1906032637
+[gh-projects-rest]: https://docs.github.com/en/rest/projects/items
+[gh-pat-classic]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
+[gh-pat-ga]: https://github.blog/changelog/2025-03-18-fine-grained-pats-are-now-generally-available/
 
 ## PAT requirements
 
@@ -104,7 +111,7 @@ Tracker repo (mirror issues + TODO.md + DONE.md)
 | Issues (read+write) on tracked repos | Forward: read. Reverse: write. |
 | Issues (read+write) on tracker repo | Forward: create/edit mirrors |
 | Contents (write) on tracker repo | Commit TODO.md/DONE.md |
-| `read:org` + `project` (classic, optional) | Projects board aggregation |
+| `read:org` + `project` ([classic PAT][gh-pat-classic], optional) | Projects board aggregation (org-owned projects only) |
 
 ## Development
 


### PR DESCRIPTION
Fine-grained PATs don't support user-owned projects. All URLs are first-party GitHub sources.