### PR TITLE
ci: replace pip bump with signed commit pattern via GitHub API

### DIFF
--- a/.github/scripts/delete_branch_pr_tag.sh
+++ b/.github/scripts/delete_branch_pr_tag.sh
@@ -1,16 +1,17 @@
-#!/usr/bin/env bash
-# delete_branch_pr_tag.sh — Cleanup on bump workflow failure/cancel.
-# Closes PR, deletes branch, release, and tag.
-# All commands guarded with || true to prevent cascading failures.
-set -euo pipefail
+#!/bin/bash
+# Cleanup on bump failure: close PR, delete branch, tag, and release.
+# Args: $1 = repo (owner/name), $2 = branch name, $3 = version (without v prefix)
 
-REPO="${GITHUB_REPOSITORY:?}"
-BRANCH="${CLEANUP_BRANCH:-}"
-TAG="${CLEANUP_TAG:-}"
-PR="${CLEANUP_PR_NUMBER:-}"
+close_msg="Closing PR '$2' to rollback after failure"
 
-[[ -n "$PR" ]]     && gh pr close "$PR" -R "$REPO" --delete-branch || true
-[[ -n "$BRANCH" ]] && gh api "repos/$REPO/git/refs/heads/$BRANCH" -X DELETE || true
-[[ -n "$TAG" ]]    && gh release delete "$TAG" -R "$REPO" --yes || true
-[[ -n "$TAG" ]]    && gh api "repos/$REPO/git/refs/tags/$TAG" -X DELETE || true
-[[ -n "$BRANCH" ]] && git branch -D "$BRANCH" || true
+echo "Closing PR for branch '$2'..."
+gh pr close "$2" --comment "$close_msg" 2>/dev/null || true
+
+echo "Deleting branch '$2'..."
+gh api "repos/$1/git/refs/heads/$2" -X DELETE 2>/dev/null || true
+
+echo "Deleting release 'v$3'..."
+gh release delete "v$3" --repo "$1" --yes 2>/dev/null || true
+
+echo "Deleting tag 'v$3'..."
+gh api "repos/$1/git/refs/tags/v$3" -X DELETE 2>/dev/null || true

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -1,90 +1,121 @@
+---
 name: Bump and Release
 
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: 'Version bump type'
+      bump_type:
+        description: '[major|minor|patch]'
         required: true
+        default: 'patch'
         type: choice
         options:
-          - patch
-          - minor
-          - major
-
-permissions:
-  contents: write
-  pull-requests: write
+        - 'major'
+        - 'minor'
+        - 'patch'
 
 env:
-  SKIP_PR_HINT: '[skip ci bump]'
+  BRANCH_NEW: "bump-${{ github.run_number }}-${{ github.ref_name }}"
+  SKIP_PR_HINT: "[skip ci bump]"
+  SCRIPT_PATH: ".github/scripts"
 
 jobs:
-  bump:
+  bump_my_version:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+
+      - name: Checkout repo
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-
-      - name: Install bump-my-version
-        run: pip install bump-my-version
-
-      - name: Configure git
-        run: |
-          git config user.name "bump-my-version"
-          git config user.email "bump-my-version@gha"
-
-      - name: Bump version
+      - name: Bump version (files only, no commit/tag)
         id: bump
-        env:
-          BUMP_TYPE: ${{ inputs.bump }}
-        run: |
-          bump-my-version bump "$BUMP_TYPE" --commit --tag
-          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
-          echo "branch=bump-${{ github.run_number }}-${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+        uses: callowayproject/bump-my-version@1.2.7
+        with:
+          args: ${{ inputs.bump_type }}
 
-      - name: Create branch and PR
+      - name: Create signed commit and push branch
+        if: steps.bump.outputs.bumped == 'true'
+        id: signed_commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ steps.bump.outputs.branch }}
-          TAG: ${{ steps.bump.outputs.tag }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ env.BRANCH_NEW }}
+          VERSION: ${{ steps.bump.outputs.current-version }}
+          PREV_VERSION: ${{ steps.bump.outputs.previous-version }}
         run: |
-          git checkout -b "$BRANCH"
-          git push origin "$BRANCH" --tags
+          BASE_SHA=$(gh api "repos/$REPO/git/ref/heads/${{ github.ref_name }}" --jq '.object.sha')
+          BASE_TREE=$(gh api "repos/$REPO/git/commits/$BASE_SHA" --jq '.tree.sha')
+
+          TREE_ENTRIES="[]"
+          for file in $(git diff --name-only); do
+            CONTENT=$(base64 -w0 "$file")
+            BLOB_SHA=$(gh api "repos/$REPO/git/blobs" -f content="$CONTENT" -f encoding=base64 --jq '.sha')
+            TREE_ENTRIES=$(echo "$TREE_ENTRIES" | jq --arg path "$file" --arg sha "$BLOB_SHA" \
+              '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
+          done
+
+          NEW_TREE=$(gh api "repos/$REPO/git/trees" \
+            --input <(jq -n --arg base "$BASE_TREE" --argjson tree "$TREE_ENTRIES" \
+              '{base_tree: $base, tree: $tree}') \
+            --jq '.sha')
+
+          COMMIT_SHA=$(gh api "repos/$REPO/git/commits" \
+            --input <(jq -n --arg msg "Bump version: $PREV_VERSION -> $VERSION" \
+              --arg tree "$NEW_TREE" --arg parent "$BASE_SHA" \
+              '{message: $msg, tree: $tree, parents: [$parent]}') \
+            --jq '.sha')
+
+          gh api "repos/$REPO/git/refs/heads/$BRANCH" -X PATCH -f sha="$COMMIT_SHA" -F force=true 2>/dev/null \
+            || gh api "repos/$REPO/git/refs" -f ref="refs/heads/$BRANCH" -f sha="$COMMIT_SHA"
+
+          gh api "repos/$REPO/git/refs" -f ref="refs/tags/v$VERSION" -f sha="$COMMIT_SHA"
+
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+
+      - name: Create PR
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag_current="v${{ steps.bump.outputs.current-version }}"
+          tag_previous="v${{ steps.bump.outputs.previous-version }}"
+          pr_title="PR ${{ env.BRANCH_NEW }} ${{ env.SKIP_PR_HINT }}"
+          pr_body="PR automatically created from \`${{ github.ref_name }}\` to bump from"
+          pr_body="${pr_body} \`${tag_previous}\` to \`${tag_current}\` on \`${{ env.BRANCH_NEW }}\`."
 
           gh pr create \
-            --title "$SKIP_PR_HINT $TAG" \
-            --body "Automated version bump to $TAG" \
-            --base main \
-            --head "$BRANCH"
+            --base "${{ github.ref_name }}" \
+            --head "${{ env.BRANCH_NEW }}" \
+            --title "${pr_title}" \
+            --body "${pr_body}"
 
       - name: Create release and update floating tag
+        if: steps.bump.outputs.bumped == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.bump.outputs.tag }}
+          TAG: v${{ steps.bump.outputs.current-version }}
           REPO: ${{ github.repository }}
         run: |
-          gh release create "$TAG" --generate-notes --repo "$REPO"
-
+          gh release create "$TAG" --repo "$REPO" --generate-notes
           MAJOR="${TAG%%.*}"
           SHA=$(gh api "repos/$REPO/git/refs/tags/$TAG" --jq '.object.sha')
-          gh api "repos/$REPO/git/refs/tags/$MAJOR" \
-            -X PATCH -f sha="$SHA" -F force=true 2>/dev/null \
-          || gh api "repos/$REPO/git/refs" \
-            -f ref="refs/tags/$MAJOR" -f sha="$SHA"
+          gh api "repos/$REPO/git/refs/tags/$MAJOR" -X PATCH -f sha="$SHA" -F force=true 2>/dev/null \
+            || gh api "repos/$REPO/git/refs" -f ref="refs/tags/$MAJOR" -f sha="$SHA"
 
-      - name: Cleanup on failure
+      - name: Delete branch, PR and tag in case of failure or cancel
         if: failure() || cancelled()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CLEANUP_BRANCH: ${{ steps.bump.outputs.branch }}
-          CLEANUP_TAG: ${{ steps.bump.outputs.tag }}
-          CLEANUP_PR_NUMBER: ''
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          chmod +x .github/scripts/delete_branch_pr_tag.sh
-          .github/scripts/delete_branch_pr_tag.sh
+          src="${{ env.SCRIPT_PATH }}/delete_branch_pr_tag.sh"
+          chmod +x "$src"
+          $src "${{ github.repository }}" "${{ env.BRANCH_NEW }}" "${{ steps.bump.outputs.current-version }}"
+
+...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [tool.bumpversion]
 current_version = "0.1.0"
-commit = true
-tag = true
+commit = false
+tag = false
+allow_dirty = true
 tag_name = "v{new_version}"
 message = "bump: {current_version} → {new_version}"
 


### PR DESCRIPTION
## Summary

- Replace `pip install bump-my-version` + `--commit --tag` + `git push` with `callowayproject/bump-my-version@1.2.7` action and GitHub API signed commit chain (Blob→Tree→Commit→Ref)
- Update `pyproject.toml`: `commit=false, tag=false, allow_dirty=true`
- Update `delete_branch_pr_tag.sh` to use positional args (`$1=repo $2=branch $3=version`) matching SOT interface

## Test plan

- [ ] Workflow structure matches `gha-contribution-ascii` SOT pattern
- [ ] CI passes

Generated with Claude <noreply@anthropic.com>