### PR TITLE
ci: add workflow_dispatch and actions: read to CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,10 @@ on:
     branches: [main]
   schedule:
     - cron: '0 4 * * 1'
+  workflow_dispatch:
 
 permissions:
+  actions: read
   security-events: write
   contents: read
 


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch:` trigger to allow manual CodeQL runs
- Add `actions: read` permission (required by CodeQL v3+)

## Test plan

- [ ] CI passes

Generated with Claude <noreply@anthropic.com>