### PR TITLE
refactor!: rename forward/reverse to pull/push

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Bidirectional GitHub issue sync across repos. Composite GitHub Action.
 
-- **Forward sync**: repo issues → tracker mirror issues + TODO.md/DONE.md
-- **Reverse sync**: tracker issue events → source repo (close, reopen, labels, assignees, title, comments)
+- **Pull sync**: repo issues → tracker mirror issues + TODO.md/DONE.md
+- **Push sync**: tracker issue events → source repo (close, reopen, labels, assignees, title, comments)
 - **Tracker-only issues**: private tasks visible only in the tracker repo
 
 ## Usage
 
-### Forward sync (scheduled)
+### Pull sync (scheduled — repos → tracker)
 
 ```yaml
-# .github/workflows/sync-forward.yml
-name: Forward sync
+# .github/workflows/sync-pull.yml
+name: Pull sync
 on:
   schedule:
     - cron: '*/15 * * * *'
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: qte77/gha-cross-repo-issue-sync@v1
         with:
-          direction: forward
+          direction: pull
           tracker_repo: owner/.github-private-project-tracker
           repos_file: repos.txt
           token: ${{ secrets.PROJECT_TRACKER_PAT }}
@@ -41,11 +41,11 @@ jobs:
           git push
 ```
 
-### Reverse sync (event-driven)
+### Push sync (event-driven — tracker → repos)
 
 ```yaml
-# .github/workflows/sync-back.yml
-name: Reverse sync
+# .github/workflows/sync-push.yml
+name: Push sync
 on:
   issues:
     types: [closed, reopened, edited, labeled, unlabeled, assigned, unassigned]
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: qte77/gha-cross-repo-issue-sync@v1
         with:
-          direction: reverse
+          direction: push
           tracker_repo: ${{ github.repository }}
           token: ${{ secrets.PROJECT_TRACKER_PAT }}
 ```
@@ -67,7 +67,7 @@ jobs:
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `direction` | Yes | — | `forward`, `reverse`, or `both` |
+| `direction` | Yes | — | `pull` (repos→tracker), `push` (tracker→repos), or `both` |
 | `tracker_repo` | Yes | — | Tracker repo (`owner/repo`) |
 | `repos_file` | No | `repos.txt` | File listing tracked repos |
 | `repos` | No | — | Comma-separated repo list (alternative to file) |

--- a/action.yaml
+++ b/action.yaml
@@ -8,17 +8,17 @@ branding:
 
 inputs:
   direction:
-    description: 'Sync direction: forward, reverse, or both'
+    description: 'Sync direction: pull (repos→tracker), push (tracker→repos), or both'
     required: true
   tracker_repo:
     description: 'Tracker repo (e.g. owner/.github-private-project-tracker)'
     required: true
   repos_file:
-    description: 'Path to repos.txt (one repo name per line). Used for forward sync.'
+    description: 'Path to repos.txt (one repo name per line). Used for pull sync.'
     required: false
     default: 'repos.txt'
   repos:
-    description: 'Comma-separated repo list (alternative to repos_file). Used for forward sync.'
+    description: 'Comma-separated repo list (alternative to repos_file). Used for pull sync.'
     required: false
   owner:
     description: 'GitHub owner/org for tracked repos'
@@ -40,11 +40,11 @@ inputs:
     required: false
     default: 'false'
   event_action:
-    description: 'Issue event action (for reverse sync). Auto-set from github.event.action.'
+    description: 'Issue event action (for push sync). Auto-set from github.event.action.'
     required: false
     default: ${{ github.event.action }}
   event_issue_number:
-    description: 'Issue number that triggered the event (for reverse sync).'
+    description: 'Issue number that triggered the event (for push sync).'
     required: false
     default: ''
   event_label:
@@ -59,8 +59,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Forward sync
-      if: inputs.direction == 'forward' || inputs.direction == 'both'
+    - name: Pull sync (repos → tracker)
+      if: inputs.direction == 'pull' || inputs.direction == 'both'
       shell: bash
       env:
         GITHUB_TOKEN: ''
@@ -75,7 +75,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
       run: |
         source "$ACTION_PATH/scripts/common.sh"
-        source "$ACTION_PATH/scripts/sync-forward.sh"
+        source "$ACTION_PATH/scripts/sync-pull.sh"
 
         # Build repo list
         repos=()
@@ -113,10 +113,10 @@ runs:
           generate_markdown "." "" "$tracker_json"
         fi
 
-        echo "Forward sync complete."
+        echo "Pull sync complete."
 
-    - name: Reverse sync
-      if: inputs.direction == 'reverse' || inputs.direction == 'both'
+    - name: Push sync (tracker → repos)
+      if: inputs.direction == 'push' || inputs.direction == 'both'
       shell: bash
       env:
         GITHUB_TOKEN: ''
@@ -134,7 +134,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
       run: |
         source "$ACTION_PATH/scripts/common.sh"
-        source "$ACTION_PATH/scripts/sync-back.sh"
+        source "$ACTION_PATH/scripts/sync-push.sh"
 
         # Loop guard
         if is_loop "$GITHUB_ACTOR" ""; then
@@ -145,7 +145,7 @@ runs:
         # Get issue body to extract source ref
         issue_num="${EVENT_ISSUE_NUMBER:-$EVENT_ISSUE_NUMBER_FALLBACK}"
         if [[ -z "$issue_num" ]]; then
-          echo "::warning::No issue number in event. Skipping reverse sync."
+          echo "::warning::No issue number in event. Skipping push sync."
           exit 0
         fi
 
@@ -153,7 +153,7 @@ runs:
         source_ref="$(parse_source_ref "$issue_body")"
 
         if [[ -z "$source_ref" ]]; then
-          echo "Tracker-only issue #$issue_num. Skipping reverse sync."
+          echo "Tracker-only issue #$issue_num. Skipping push sync."
           exit 0
         fi
 
@@ -173,4 +173,4 @@ runs:
 
         dispatch_event "$action" "$source_ref" "$repo" "$EVENT_LABEL" "$title" "$EVENT_ASSIGNEE" "$comment"
 
-        echo "Reverse sync complete for $source_ref ($action)."
+        echo "Push sync complete for $source_ref ($action)."

--- a/scripts/sync-pull.sh
+++ b/scripts/sync-pull.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# sync-forward.sh — Forward sync: repo issues → tracker mirrors + markdown.
+# sync-pull.sh — Pull sync: repo issues → tracker mirrors + markdown.
 # Requires common.sh to be sourced first.
 
 DRY_RUN="${DRY_RUN:-false}"

--- a/scripts/sync-push.sh
+++ b/scripts/sync-push.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# sync-back.sh — Reverse sync: tracker issue events → source repo.
+# sync-push.sh — Push sync: tracker issue events → source repo.
 # Requires common.sh to be sourced first.
 
 DRY_RUN="${DRY_RUN:-false}"

--- a/tests/unit/test_sync_pull.bats
+++ b/tests/unit/test_sync_pull.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-# Phase 3 TDD: tests for scripts/sync-forward.sh
-# Tests forward sync (repo issues → tracker mirrors + markdown).
+# Phase 3 TDD: tests for scripts/sync-pull.sh
+# Tests pull sync (repo issues → tracker mirrors + markdown).
 
 FIXTURES="$BATS_TEST_DIRNAME/../fixtures"
 
@@ -20,7 +20,7 @@ setup() {
 
   source "$BATS_TEST_DIRNAME/../test_helper/gh_mock.bash"
   source "$BATS_TEST_DIRNAME/../../scripts/common.sh"
-  source "$BATS_TEST_DIRNAME/../../scripts/sync-forward.sh"
+  source "$BATS_TEST_DIRNAME/../../scripts/sync-pull.sh"
 }
 
 teardown() {

--- a/tests/unit/test_sync_push.bats
+++ b/tests/unit/test_sync_push.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-# Phase 2 TDD: tests for scripts/sync-back.sh
-# Tests reverse sync (tracker → source repo) using mocked gh CLI.
+# Phase 2 TDD: tests for scripts/sync-push.sh
+# Tests push sync (tracker → source repo) using mocked gh CLI.
 
 setup() {
   export TMPDIR="${BATS_TMPDIR:-/tmp/claude-1000/bats-tmp}"
@@ -9,7 +9,7 @@ setup() {
   rm -f "$GH_MOCK_LOG"
   source "$BATS_TEST_DIRNAME/../test_helper/gh_mock.bash"
   source "$BATS_TEST_DIRNAME/../../scripts/common.sh"
-  source "$BATS_TEST_DIRNAME/../../scripts/sync-back.sh"
+  source "$BATS_TEST_DIRNAME/../../scripts/sync-push.sh"
 }
 
 teardown() {


### PR DESCRIPTION
## Summary

**BREAKING**: direction input values changed:
- `forward` → `pull` (repos → tracker)
- `reverse` → `push` (tracker → repos)

Renames throughout:
- `sync-forward.sh` → `sync-pull.sh`
- `sync-back.sh` → `sync-push.sh`
- Test files, action.yaml step names, descriptions, README examples

## Migration

Update your workflow files:
```yaml
# Before
direction: forward  # or reverse
# After
direction: pull     # or push
```

## Test plan

- [ ] BATS tests pass
- [ ] Update tracker workflows (`sync.yml` → `sync-pull.yml`, `sync-back.yml` → `sync-push.yml`) after merge

Generated with Claude <noreply@anthropic.com>