### PR TITLE
refactor: strict TDD cleanup of test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored test suite for strict TDD behavior-first compliance (92 → 104 tests)
+- Refactored `test_infra_files.bats` from brittle content matching to contract tests
+- Added round-trip tests for `build_mirror_body` → `parse_source_ref`
+- Added dry-run preview message verification tests
+- Added multiline comment sync test
+- Added markdown format validation tests (checkbox format, section headers, multi-repo append)
+- Added error injection support to `gh_mock.bash` (`GH_MOCK_FAIL_CMD`)
+- Added error handling tests for `sync_repo` and `handle_issue_closed`
+- Added edge case tests for special characters in titles
+
+### Added
+
+- `Makefile` with `setup_dev`, `test`, `lint`, `clean` recipes
+
 ---
 
 ## [0.2.0] - 2026-03-30

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+# Makefile for gha-cross-repo-issue-sync development.
+# Run `make help` to see all available recipes.
+
+.SILENT:
+.ONESHELL:
+.PHONY: setup_dev test lint clean help
+.DEFAULT_GOAL := help
+
+
+# MARK: SETUP
+
+
+setup_dev:  ## Install dev dependencies (bats, shellcheck, actionlint)
+	echo "Setting up dev environment ..."
+	command -v bats >/dev/null || npm install -g bats
+	if command -v apt-get > /dev/null; then
+		command -v shellcheck >/dev/null || sudo apt-get install -y shellcheck
+		command -v actionlint >/dev/null || { \
+			echo "Install actionlint: https://github.com/rhysd/actionlint#install"; }
+	fi
+	echo "Dev environment ready."
+	echo "  bats:        $$(bats --version 2>/dev/null || echo 'not installed')"
+	echo "  shellcheck:  $$(shellcheck --version 2>/dev/null | grep '^version:' || echo 'not installed')"
+	echo "  actionlint:  $$(actionlint --version 2>/dev/null || echo 'not installed')"
+
+
+# MARK: QUALITY
+
+
+test:  ## Run all BATS tests
+	bats tests/unit/
+
+lint:  ## Run shellcheck on scripts
+	shellcheck scripts/*.sh
+
+
+# MARK: CLEANUP
+
+
+clean:  ## Remove test artifacts
+	rm -rf /tmp/claude-*/bats-tmp
+	echo "Test artifacts cleaned."
+
+
+# MARK: HELP
+
+
+help:  ## Show available recipes grouped by section
+	@echo "Usage: make [recipe]"
+	@echo ""
+	@awk '/^# MARK:/ { \
+		section = substr($$0, index($$0, ":")+2); \
+		printf "\n\033[1m%s\033[0m\n", section \
+	} \
+	/^[a-zA-Z0-9_-]+:.*?##/ { \
+		helpMessage = match($$0, /## (.*)/); \
+		if (helpMessage) { \
+			recipe = $$1; \
+			sub(/:/, "", recipe); \
+			printf "  \033[36m%-22s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH) \
+		} \
+	}' $(MAKEFILE_LIST)

--- a/tests/test_helper/gh_mock.bash
+++ b/tests/test_helper/gh_mock.bash
@@ -8,6 +8,12 @@ export GH_MOCK_LOG="${GH_MOCK_LOG:-$BATS_TMPDIR/gh_mock.log}"
 gh() {
   echo "gh $*" >> "$GH_MOCK_LOG"
 
+  # Error injection: if GH_MOCK_FAIL_CMD matches, return exit 1
+  if [[ -n "${GH_MOCK_FAIL_CMD:-}" && "$1 $2" == "$GH_MOCK_FAIL_CMD" ]]; then
+    echo "gh: mock error for $1 $2" >&2
+    return 1
+  fi
+
   case "$1 $2" in
     "issue list")
       # Detect which repo is being queried via -R flag

--- a/tests/unit/test_common.bats
+++ b/tests/unit/test_common.bats
@@ -133,3 +133,26 @@ setup() {
   result="$(build_pr_mirror_body "qte77/repo#5")"
   echo "$result" | grep -q "Source: qte77/repo#5 (PR)"
 }
+
+# --- round-trip: build → parse ---
+
+@test "build_mirror_body round-trips through parse_source_ref" {
+  ref="qte77/my-repo#42"
+  body="$(build_mirror_body "$ref")"
+  result="$(parse_source_ref "$body")"
+  [ "$result" = "$ref" ]
+}
+
+@test "build_pr_mirror_body round-trips through parse_source_ref and is_pr_mirror" {
+  ref="qte77/pr-repo#7"
+  body="$(build_pr_mirror_body "$ref")"
+  result="$(parse_source_ref "$body")"
+  [ "$result" = "$ref" ]
+  is_pr_mirror "$body"
+}
+
+@test "parse_source_ref finds ref regardless of line position in body" {
+  body="Title line\nSome description\nSource: qte77/deep-repo#99\nFooter"
+  result="$(parse_source_ref "$body")"
+  [ "$result" = "qte77/deep-repo#99" ]
+}

--- a/tests/unit/test_infra_files.bats
+++ b/tests/unit/test_infra_files.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-# Phase 5 TDD: validation tests for repo infra files.
-# Checks that required files exist with correct structure.
+# Contract tests: required repo infrastructure files exist.
+# Tests file presence and executability — NOT content details.
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 
@@ -9,9 +9,9 @@ setup() {
   export TMPDIR="${BATS_TMPDIR:-/tmp/claude-1000/bats-tmp}"
 }
 
-# --- action.yaml ---
+# --- action definition ---
 
-@test "action.yaml exists and has required branding fields" {
+@test "action.yaml exists with required marketplace fields" {
   [ -f "$REPO_ROOT/action.yaml" ]
   grep -q "^name:" "$REPO_ROOT/action.yaml"
   grep -q "^description:" "$REPO_ROOT/action.yaml"
@@ -19,76 +19,54 @@ setup() {
   grep -q "color:" "$REPO_ROOT/action.yaml"
 }
 
-@test "action.yaml unsets GITHUB_TOKEN so PAT takes precedence" {
-  # gh CLI resolves GITHUB_TOKEN > GH_TOKEN; must unset in GHA
-  local count
-  count="$(grep -c "GITHUB_TOKEN: ''" "$REPO_ROOT/action.yaml")"
-  [ "$count" -eq 2 ]
+# --- CI/CD workflows ---
+
+@test "CI workflow exists for running tests" {
+  [ -f "$REPO_ROOT/.github/workflows/test.yml" ]
 }
 
-# --- dependabot ---
-
-@test "dependabot.yml exists and covers github-actions ecosystem" {
-  [ -f "$REPO_ROOT/.github/dependabot.yml" ]
-  grep -q "github-actions" "$REPO_ROOT/.github/dependabot.yml"
+@test "release workflow exists for version bumps" {
+  [ -f "$REPO_ROOT/.github/workflows/bump-and-release.yml" ]
 }
 
-# --- codeql ---
-
-@test "codeql workflow exists" {
+@test "CodeQL security scanning workflow exists" {
   [ -f "$REPO_ROOT/.github/workflows/codeql.yml" ]
 }
 
-# --- bump-my-version ---
-
-@test "bump-and-release workflow exists" {
-  [ -f "$REPO_ROOT/.github/workflows/bump-and-release.yml" ]
-  grep -q "bump-my-version" "$REPO_ROOT/.github/workflows/bump-and-release.yml"
+@test "Dependabot configuration exists" {
+  [ -f "$REPO_ROOT/.github/dependabot.yml" ]
 }
 
-@test "pyproject.toml has bumpversion config" {
+# --- version management ---
+
+@test "pyproject.toml exists with bumpversion config" {
   [ -f "$REPO_ROOT/pyproject.toml" ]
   grep -q "tool.bumpversion" "$REPO_ROOT/pyproject.toml"
 }
 
-# --- cleanup script ---
+# --- scripts ---
 
 @test "cleanup script exists and is executable" {
   [ -f "$REPO_ROOT/.github/scripts/delete_branch_pr_tag.sh" ]
   [ -x "$REPO_ROOT/.github/scripts/delete_branch_pr_tag.sh" ]
 }
 
-# --- .gitmessage ---
+# --- contributor templates ---
 
-@test ".gitmessage exists with conventional commit hint" {
-  [ -f "$REPO_ROOT/.gitmessage" ]
-  grep -qi "feat\|fix\|chore\|docs" "$REPO_ROOT/.gitmessage"
-}
-
-# --- issue template ---
-
-@test "issue template exists" {
-  [ -f "$REPO_ROOT/.github/ISSUE_TEMPLATE/bug_report.md" ] || \
-  [ -f "$REPO_ROOT/.github/ISSUE_TEMPLATE/bug_report.yml" ] || \
+@test "issue template directory exists" {
   [ -d "$REPO_ROOT/.github/ISSUE_TEMPLATE" ]
 }
-
-# --- PR template ---
 
 @test "PR template exists" {
   [ -f "$REPO_ROOT/.github/pull_request_template.md" ]
 }
 
-# --- BATS CI ---
-
-@test "CI workflow runs bats tests" {
-  [ -f "$REPO_ROOT/.github/workflows/test.yml" ]
-  grep -q "bats" "$REPO_ROOT/.github/workflows/test.yml"
+@test "commit message template exists" {
+  [ -f "$REPO_ROOT/.gitmessage" ]
 }
 
-# --- LICENSE ---
+# --- license ---
 
-@test "LICENSE exists with Apache-2.0" {
+@test "LICENSE file exists" {
   [ -f "$REPO_ROOT/LICENSE" ]
-  grep -q "Apache License" "$REPO_ROOT/LICENSE"
 }

--- a/tests/unit/test_sync_pull.bats
+++ b/tests/unit/test_sync_pull.bats
@@ -148,6 +148,12 @@ gh_calls() {
   [ ! -f "$GH_MOCK_LOG" ] || ! gh_calls | grep -q "gh issue close"
 }
 
+@test "sync_repo dry-run prints preview message for new issues" {
+  export DRY_RUN=true
+  run sync_repo "test-repo"
+  [[ "$output" == *"[dry-run] Would create mirror"* ]]
+}
+
 # --- generate_markdown ---
 
 @test "generate_markdown writes TODO.md with open issues" {
@@ -171,6 +177,28 @@ gh_calls() {
 @test "generate_markdown includes tracker-only issues in TODO.md" {
   generate_markdown "$MARKDOWN_DIR" "" "$GH_MOCK_MIRROR_JSON"
   grep -q "Private planning task" "$MARKDOWN_DIR/TODO.md"
+}
+
+@test "generate_markdown uses checkbox format for open issues" {
+  generate_markdown "$MARKDOWN_DIR" "test-repo" "$GH_MOCK_SOURCE_JSON"
+  grep -q '^\- \[ \] ' "$MARKDOWN_DIR/TODO.md"
+}
+
+@test "generate_markdown uses checked format for closed issues" {
+  generate_markdown "$MARKDOWN_DIR" "test-repo" "$GH_MOCK_SOURCE_JSON"
+  grep -q '^\- \[x\] ' "$MARKDOWN_DIR/DONE.md"
+}
+
+@test "generate_markdown includes section header with repo name" {
+  generate_markdown "$MARKDOWN_DIR" "test-repo" "$GH_MOCK_SOURCE_JSON"
+  grep -q '^## test-repo' "$MARKDOWN_DIR/TODO.md"
+}
+
+@test "generate_markdown appends sections for multiple repos" {
+  generate_markdown "$MARKDOWN_DIR" "repo-a" "$GH_MOCK_SOURCE_JSON"
+  generate_markdown "$MARKDOWN_DIR" "repo-b" "$GH_MOCK_SOURCE_JSON"
+  grep -q '## repo-a' "$MARKDOWN_DIR/TODO.md"
+  grep -q '## repo-b' "$MARKDOWN_DIR/TODO.md"
 }
 
 # --- sync_mirror_comments ---
@@ -202,6 +230,13 @@ gh_calls() {
   export GH_MOCK_MIRROR_COMMENTS='[]'
   DRY_RUN=true sync_mirror_comments 1 10 "qte77/test-repo"
   [ ! -f "$GH_MOCK_LOG" ] || ! gh_calls | grep -q "gh issue comment 10"
+}
+
+@test "sync_mirror_comments preserves multiline comment body" {
+  export GH_MOCK_SOURCE_COMMENTS='[{"id":100,"body":"Line one\nLine two\nLine three","user":{"login":"alice"}}]'
+  export GH_MOCK_MIRROR_COMMENTS='[]'
+  sync_mirror_comments 1 10 "qte77/test-repo"
+  gh_calls | grep -q "gh issue comment 10"
 }
 
 # --- sync_repo_prs ---
@@ -250,4 +285,13 @@ gh_calls() {
   update_pr_status_label 20 "CLOSED"
   gh_calls | grep -q "\-\-add-label pr:closed"
   gh_calls | grep -q "\-\-remove-label pr:open"
+}
+
+# --- error handling ---
+
+@test "sync_repo handles gh issue list failure gracefully" {
+  export GH_MOCK_FAIL_CMD="issue list"
+  run sync_repo "test-repo"
+  # Should not crash — exits 0 or handles the error
+  [ "$status" -eq 0 ]
 }

--- a/tests/unit/test_sync_push.bats
+++ b/tests/unit/test_sync_push.bats
@@ -61,6 +61,11 @@ gh_calls() {
   gh_calls | grep -q 'gh issue edit 2 -R qte77/test-repo --title New title'
 }
 
+@test "handle_issue_edited handles title with special characters" {
+  handle_issue_edited "qte77/test-repo#2" "qte77/test-repo" "Fix: handle 'quotes' & \"doubles\""
+  gh_calls | grep -q "gh issue edit 2 -R qte77/test-repo --title"
+}
+
 # --- handle_issue_assigned ---
 
 @test "handle_issue_assigned adds assignee to source issue" {
@@ -140,6 +145,13 @@ gh_calls() {
   [ ! -f "$GH_MOCK_LOG" ] || [ ! -s "$GH_MOCK_LOG" ]
 }
 
+@test "dispatch_event dry-run prints preview with action and ref" {
+  run bash -c 'DRY_RUN=true; source "'"$BATS_TEST_DIRNAME"'/../../scripts/common.sh"; source "'"$BATS_TEST_DIRNAME"'/../../scripts/sync-push.sh"; dispatch_event "closed" "qte77/test-repo#1" "qte77/test-repo" "" "" ""'
+  [[ "$output" == *"[dry-run]"* ]]
+  [[ "$output" == *"closed"* ]]
+  [[ "$output" == *"qte77/test-repo#1"* ]]
+}
+
 # --- Guard: unknown action ---
 
 @test "dispatch_event prints error for unknown action" {
@@ -147,4 +159,14 @@ gh_calls() {
   [ "$status" -eq 0 ]
   echo "$output" | grep -q "Unknown action: invalid_action"
   [ ! -f "$GH_MOCK_LOG" ] || [ ! -s "$GH_MOCK_LOG" ]
+}
+
+# --- error handling ---
+
+@test "handle_issue_closed does not crash when gh fails" {
+  export GH_MOCK_FAIL_CMD="issue close"
+  run handle_issue_closed "qte77/test-repo#5" "qte77/test-repo"
+  # gh failure propagates but should not cause unexpected behavior
+  [ "$status" -ne 0 ]
+  gh_calls | grep -q "gh issue close"
 }


### PR DESCRIPTION
## Summary
- Refactored test suite for strict TDD behavior-first compliance (92 → 104 tests)
- Refactored `test_infra_files.bats` from brittle content matching to contract tests
- Added error injection support (`GH_MOCK_FAIL_CMD`) to `gh_mock.bash`
- Added round-trip, dry-run, multiline, markdown format, and error handling tests
- Added `Makefile` with `setup_dev`, `test`, `lint`, `clean` recipes (Agents-eval pattern)

## Test plan
- [x] All 104 BATS tests pass (`bats tests/unit/`)
- [x] No regressions from baseline (92 tests)
- [ ] CI workflow passes on GitHub

Generated with Claude <noreply@anthropic.com>