### PR TITLE
fix: bump README version badge to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bidirectional GitHub issue sync across repos. Composite GitHub Action.
 
-![Version](https://img.shields.io/badge/version-0.2.0-8A2BE2)
+![Version](https://img.shields.io/badge/version-0.3.0-8A2BE2)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Tests](https://github.com/qte77/gha-cross-repo-issue-sync/actions/workflows/test.yml/badge.svg)](https://github.com/qte77/gha-cross-repo-issue-sync/actions/workflows/test.yml)
 [![CodeFactor](https://www.codefactor.io/repository/github/qte77/gha-cross-repo-issue-sync/badge)](https://www.codefactor.io/repository/github/qte77/gha-cross-repo-issue-sync)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,8 @@ replace = "# version: {new_version}"
 filename = "CHANGELOG.md"
 search = "## [Unreleased]\n\n---"
 replace = "## [Unreleased]\n\n---\n\n## [{new_version}] - {now:%Y-%m-%d}"
+
+[[tool.bumpversion.files]]
+filename = "README.md"
+search = "badge/version-{current_version}-8A2BE2"
+replace = "badge/version-{new_version}-8A2BE2"


### PR DESCRIPTION
## Summary
- Update README version badge from 0.2.0 to 0.3.0
- Add README.md to bumpversion files config so future bumps update it automatically

## Test plan
- [x] Badge shows 0.3.0
- [x] pyproject.toml search/replace pattern matches badge format

Generated with Claude <noreply@anthropic.com>