### PR TITLE
refactor: fix PAT table terminology, add RED tests for reusable workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ Tracker repo (mirror issues + TODO.md + DONE.md)
 
 | Scope | Why |
 |---|---|
-| Issues (read+write) on tracked repos | Forward: read. Reverse: write. |
-| Issues (read+write) on tracker repo | Forward: create/edit mirrors |
+| Issues (read+write) on tracked repos | Pull: read. Push: write. |
+| Issues (read+write) on tracker repo | Pull: create/edit mirrors |
 | Contents (write) on tracker repo | Commit TODO.md/DONE.md |
 | `read:org` + `project` ([classic PAT][gh-pat-classic], optional) | Projects board aggregation (org-owned projects only) |
 

--- a/tests/unit/test_infra_files.bats
+++ b/tests/unit/test_infra_files.bats
@@ -33,6 +33,14 @@ setup() {
   [ -f "$REPO_ROOT/.github/workflows/integration.yml" ]
 }
 
+@test "Reusable pull sync workflow exists" {
+  [ -f "$REPO_ROOT/.github/workflows/reusable-pull.yml" ]
+}
+
+@test "Reusable push sync workflow exists" {
+  [ -f "$REPO_ROOT/.github/workflows/reusable-push.yml" ]
+}
+
 @test "CodeQL security scanning workflow exists" {
   [ -f "$REPO_ROOT/.github/workflows/codeql.yml" ]
 }


### PR DESCRIPTION
## Summary
- Fix Forward/Reverse → Pull/Push in PAT requirements table
- Add RED contract tests for reusable-pull.yml and reusable-push.yml (will pass after #feat branch)

## Test plan
- [x] 2 new infra tests fail (RED confirmed — files don't exist yet)
- [x] All other 116 tests pass

Generated with Claude <noreply@anthropic.com>