### PR TITLE
fix: use REST API for account mode (GraphQL scope issue)

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -86,17 +86,18 @@ build_repo_list() {
       fi
       ;;
     account)
-      local jq_filter='.[] | .name'
-      [[ "${INCLUDE_ARCHIVED:-false}" != "true" ]] && jq_filter=".[] | select(.isArchived==false) | .name"
-      [[ "${INCLUDE_FORKS:-false}" != "true" ]] && jq_filter=".[] | select(.isFork==false)$(
-        [[ "${INCLUDE_ARCHIVED:-false}" != "true" ]] && echo " | select(.isArchived==false)"
-      ) | .name"
-
       local tracker_name=""
       [[ -n "${TRACKER_REPO:-}" ]] && tracker_name="${TRACKER_REPO##*/}"
 
+      # Use REST API (works with fine-grained PATs, unlike gh repo list which needs GraphQL)
+      local jq_filter='.[] | .name'
+      [[ "${INCLUDE_ARCHIVED:-false}" != "true" ]] && jq_filter=".[] | select(.archived==false) | .name"
+      [[ "${INCLUDE_FORKS:-false}" != "true" ]] && jq_filter=".[] | select(.fork==false)$(
+        [[ "${INCLUDE_ARCHIVED:-false}" != "true" ]] && echo " | select(.archived==false)"
+      ) | .name"
+
       local repos
-      repos="$(gh repo list "$OWNER" --limit 1000 --json name,isArchived,isFork --jq "$jq_filter")" || return 0
+      repos="$(gh api "users/$OWNER/repos" --paginate --jq "$jq_filter" 2>/dev/null)" || return 0
 
       while IFS= read -r repo; do
         [[ -z "$repo" ]] && continue

--- a/tests/test_helper/gh_mock.bash
+++ b/tests/test_helper/gh_mock.bash
@@ -38,13 +38,6 @@ gh() {
         echo "[]"
       fi
       ;;
-    "repo list")
-      if [[ -n "${GH_MOCK_REPO_LIST:-}" ]]; then
-        echo "$GH_MOCK_REPO_LIST"
-      else
-        printf '%s\n' "repo-a" "repo-b" "repo-c"
-      fi
-      ;;
     "issue view")
       if [[ -n "${GH_MOCK_ISSUE_JSON:-}" ]]; then
         echo "$GH_MOCK_ISSUE_JSON"
@@ -55,8 +48,15 @@ gh() {
     "project item-add") echo "" ;;
     "api "*)
       local args="$*"
+      # Return mock repos for account mode
+      if [[ "$args" == *"/repos"* && "$args" != *"/comments"* ]]; then
+        if [[ -n "${GH_MOCK_REPO_LIST:-}" ]]; then
+          echo "$GH_MOCK_REPO_LIST"
+        else
+          printf '%s\n' "repo-a" "repo-b" "repo-c"
+        fi
       # Return mock comments for issue API calls
-      if [[ "$args" == *"/comments"* ]]; then
+      elif [[ "$args" == *"/comments"* ]]; then
         if [[ "$args" == *"$GH_MOCK_TRACKER_REPO"* && -n "${GH_MOCK_MIRROR_COMMENTS:-}" ]]; then
           echo "$GH_MOCK_MIRROR_COMMENTS"
         elif [[ -n "${GH_MOCK_SOURCE_COMMENTS:-}" ]]; then

--- a/tests/unit/test_common.bats
+++ b/tests/unit/test_common.bats
@@ -197,7 +197,7 @@ setup() {
   [ "${result[0]}" = "default-repo" ]
 }
 
-@test "build_repo_list account mode returns repos from gh repo list" {
+@test "build_repo_list account mode returns repos from REST API" {
   source "$BATS_TEST_DIRNAME/../test_helper/gh_mock.bash"
   export REPO_SOURCE="account"
   export OWNER="test-org"
@@ -207,7 +207,7 @@ setup() {
   [ "${result[0]}" = "repo-a" ]
 }
 
-@test "build_repo_list account mode calls gh repo list with correct owner" {
+@test "build_repo_list account mode calls REST API with correct owner" {
   export GH_MOCK_LOG="$BATS_TMPDIR/gh_mock_brl_$$.log"
   rm -f "$GH_MOCK_LOG"
   source "$BATS_TEST_DIRNAME/../test_helper/gh_mock.bash"
@@ -215,7 +215,7 @@ setup() {
   export OWNER="test-org"
   export TRACKER_REPO=""
   build_repo_list > /dev/null
-  grep -q "gh repo list test-org" "$GH_MOCK_LOG"
+  grep -q "gh api users/test-org/repos" "$GH_MOCK_LOG"
   rm -f "$GH_MOCK_LOG"
 }
 


### PR DESCRIPTION
## Summary
- Replace `gh repo list` (GraphQL) with `gh api users/{owner}/repos` (REST) for account mode
- Fine-grained PATs and `GITHUB_TOKEN` lack GraphQL access, causing HTTP 401 in account mode
- REST API works with all PAT types and supports `--paginate`

## Test plan
- [x] 116 BATS tests pass (account mode tests updated)
- [ ] CI passes
- [ ] Tracker repo account mode dispatch works

Generated with Claude <noreply@anthropic.com>