### PR TITLE
fix: expose GITHUB_TOKEN in composite action env for account mode (#54)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -77,6 +77,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        GITHUB_TOKEN: ${{ github.token }}
         TRACKER_REPO: ${{ inputs.tracker_repo }}
         OWNER: ${{ inputs.owner }}
         DRY_RUN: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Summary
Add `GITHUB_TOKEN: ${{ github.token }}` to pull sync env block. Composite action steps don't inherit the runner's automatic `GITHUB_TOKEN`. Account mode needs it for `gh api users/{owner}/repos` (the PAT lacks `metadata:read`).

Closes #54

## Test plan
- [x] 116 BATS tests pass
- [ ] CI passes (account mode dry-run)
- [ ] Tracker repo account mode dispatch lists repos after bump

Generated with Claude <noreply@anthropic.com>