### PR TITLE
fix: clear TODO.md/DONE.md before markdown generation

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -110,6 +110,9 @@ runs:
 
         # Generate markdown
         if [[ "$GENERATE_MARKDOWN" == "true" ]]; then
+          # Clear prior output so repeated syncs don't append duplicate sections
+          reset_markdown "."
+
           # Fetch all tracker issues for markdown (mirrors + tracker-only)
           tracker_json="$(gh issue list -R "$TRACKER_REPO" --state all --limit 500 \
             --json number,title,body,state 2>/dev/null || echo "[]")"

--- a/scripts/sync-pull.sh
+++ b/scripts/sync-pull.sh
@@ -315,6 +315,14 @@ sync_mirror_comments() {
   done < <(echo "$src_comments" | jq -c '.[]')
 }
 
+# Remove any prior TODO.md / DONE.md in the output dir so a fresh sync run
+# starts with an empty file instead of appending a new section to stale output.
+# Args: $1 = output dir
+reset_markdown() {
+  local out_dir="$1"
+  rm -f "$out_dir/TODO.md" "$out_dir/DONE.md"
+}
+
 # Generate TODO.md and DONE.md from issues JSON.
 # Args: $1 = output dir, $2 = repo name (empty = tracker-only), $3 = issues JSON
 generate_markdown() {

--- a/tests/unit/test_sync_pull.bats
+++ b/tests/unit/test_sync_pull.bats
@@ -201,6 +201,33 @@ gh_calls() {
   grep -q '## repo-b' "$MARKDOWN_DIR/TODO.md"
 }
 
+# --- reset_markdown ---
+
+@test "reset_markdown removes prior TODO.md and DONE.md" {
+  generate_markdown "$MARKDOWN_DIR" "repo-a" "$GH_MOCK_SOURCE_JSON"
+  [ -f "$MARKDOWN_DIR/TODO.md" ]
+  [ -f "$MARKDOWN_DIR/DONE.md" ]
+  reset_markdown "$MARKDOWN_DIR"
+  [ ! -f "$MARKDOWN_DIR/TODO.md" ]
+  [ ! -f "$MARKDOWN_DIR/DONE.md" ]
+}
+
+@test "reset_markdown + generate_markdown twice produces single section per repo" {
+  # First sync
+  generate_markdown "$MARKDOWN_DIR" "repo-a" "$GH_MOCK_SOURCE_JSON"
+  # Second sync — caller must reset first
+  reset_markdown "$MARKDOWN_DIR"
+  generate_markdown "$MARKDOWN_DIR" "repo-a" "$GH_MOCK_SOURCE_JSON"
+  # Exactly one '## repo-a' header, exactly one '# TODO' header
+  [ "$(grep -c '^## repo-a$' "$MARKDOWN_DIR/TODO.md")" -eq 1 ]
+  [ "$(grep -c '^# TODO$' "$MARKDOWN_DIR/TODO.md")" -eq 1 ]
+}
+
+@test "reset_markdown is safe when files do not exist" {
+  reset_markdown "$MARKDOWN_DIR"
+  [ ! -f "$MARKDOWN_DIR/TODO.md" ]
+}
+
 # --- sync_mirror_comments ---
 
 @test "sync_mirror_comments syncs new source comment to mirror" {


### PR DESCRIPTION
Root cause: `generate_markdown` (scripts/sync-pull.sh) appends when `TODO.md`/`DONE.md` exist, so repeated pull syncs stack duplicate `## <repo>` sections on stale output.

Fix: new `reset_markdown()` helper; called from action.yaml at the top of the markdown-generation block, before the per-repo loop.

Tests: three new bats tests in `test_sync_pull.bats` cover removal, single-section-per-repo after double sync, and safe behavior when files don't exist.

Closes #59