### PR TITLE
fix: loosen bumpversion CHANGELOG search to anchor on separator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,12 @@ search = "# version: {current_version}"
 replace = "# version: {new_version}"
 
 [[tool.bumpversion.files]]
+# Anchor on the sole '---' separator so notes authored under [Unreleased]
+# do not break the match. New version header is inserted after the separator.
 filename = "CHANGELOG.md"
-search = "## [Unreleased]\n\n---"
-replace = "## [Unreleased]\n\n---\n\n## [{new_version}] - {now:%Y-%m-%d}"
+regex = true
+search = "^---$"
+replace = "---\n\n## [{new_version}] - {now:%Y-%m-%d}"
 
 [[tool.bumpversion.files]]
 filename = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ search = "# version: {current_version}"
 replace = "# version: {new_version}"
 
 [[tool.bumpversion.files]]
-# Anchor on the sole '---' separator so notes authored under [Unreleased]
-# do not break the match. New version header is inserted after the separator.
+# Anchor on '---' separator (not '[Unreleased]\n\n---') so notes under
+# [Unreleased] don't break the match.
 filename = "CHANGELOG.md"
 regex = true
 search = "^---$"


### PR DESCRIPTION
Root cause: `[[tool.bumpversion.files]]` for CHANGELOG.md used literal search `## [Unreleased]\\n\\n---`, requiring `---` exactly two lines below the heading. Any release notes authored under [Unreleased] (Keep-a-Changelog flow) broke the match and bump-my-version silently skipped the file.

Fix: regex mode anchored on `^---$` (sole horizontal rule in this CHANGELOG). Unreleased notes stay in place above the separator; new version header is inserted below.

No unit test added — pattern is exercised by the next `bump-and-release` workflow dispatch. Adding a real bump-my-version invocation to the bats suite would introduce a new dev dep and break the mock-only test pattern.

Closes #58