### PR TITLE
chore(lint): bump SHA pin and apply inference fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+# Pull Request Template
+
 ## Summary
 
 ## Test plan

--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
 ...

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
           git diff --cached --quiet && exit 0
           git commit -m "chore: sync TODO/DONE"
           git push
-```
+```python
 
 ### Pull sync with account mode (all repos for owner)
 
@@ -98,7 +98,7 @@ jobs:
             -f 'client_payload[repo]=${{ github.event.repository.name }}'
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TRACKER_PAT }}
-```
+```python
 
 ### Push sync (event-driven — tracker → repos)
 
@@ -145,7 +145,7 @@ jobs:
 
 ## How it works
 
-```
+```text
 Source repos (issues = SOT)
     ↕ bidirectional sync
 Tracker repo (mirror issues + TODO.md + DONE.md)
@@ -186,7 +186,7 @@ bats tests/unit/
 bats tests/unit/test_common.bats
 bats tests/unit/test_sync_push.bats
 bats tests/unit/test_sync_pull.bats
-```
+```text
 
 ## License
 


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA pin to current `qte77/.github` main (2026-04-27, includes #20 schedule-skip-md and #21 cli2 docs)
- Apply markdown inference fixes for canonical lint compliance (where applicable):
  - MD040 (fence language) inferred from block content (bash/python/json/yaml/text)
  - MD041 (first-line H1) inferred from filename
  - MD025 (multiple H1s) demoted to H2
  - MD036 (emphasis-as-heading) converted to H3

Generated with Claude <noreply@anthropic.com>